### PR TITLE
feat: Payment 파싱

### DIFF
--- a/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
+++ b/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
@@ -14,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.koreatech.payment.client.dto.PaymentConfirmResponse;
 import in.koreatech.payment.client.exception.TossPaymentErrorResponse;
 import in.koreatech.payment.client.dto.TossPaymentConfirmRequest;
 import in.koreatech.payment.client.exception.TossPaymentErrorCode;
@@ -44,15 +45,15 @@ public class TossPaymentClient {
             .build();
     }
 
-    public void requestConfirm(String paymentKey, String orderId, Integer amount) {
+    public PaymentConfirmResponse requestConfirm(String paymentKey, String orderId, Integer amount) {
         TossPaymentConfirmRequest request = new TossPaymentConfirmRequest(paymentKey, orderId, amount);
 
         try {
-            webClient.post()
+            return webClient.post()
                 .uri("/confirm")
                 .bodyValue(request)
                 .retrieve()
-                .bodyToMono(String.class)
+                .bodyToMono(PaymentConfirmResponse.class)
                 .block();
 
         } catch (WebClientResponseException e) {

--- a/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
+++ b/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
@@ -14,13 +14,12 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.koreatech.payment.client.dto.PaymentConfirmResponse;
+import in.koreatech.payment.client.dto.response.PaymentConfirmResponse;
 import in.koreatech.payment.client.exception.TossPaymentErrorResponse;
-import in.koreatech.payment.client.dto.TossPaymentConfirmRequest;
+import in.koreatech.payment.client.dto.request.PaymentConfirmRequest;
 import in.koreatech.payment.client.exception.TossPaymentErrorCode;
 import in.koreatech.payment.client.exception.TossPaymentException;
 import in.koreatech.payment.common.exception.custom.KoinIllegalStateException;
-import lombok.extern.slf4j.Slf4j;
 
 @Component
 public class TossPaymentClient {
@@ -46,7 +45,7 @@ public class TossPaymentClient {
     }
 
     public PaymentConfirmResponse requestConfirm(String paymentKey, String orderId, Integer amount) {
-        TossPaymentConfirmRequest request = new TossPaymentConfirmRequest(paymentKey, orderId, amount);
+        PaymentConfirmRequest request = new PaymentConfirmRequest(paymentKey, orderId, amount);
 
         try {
             return webClient.post()

--- a/src/main/java/in/koreatech/payment/client/dto/PaymentConfirmResponse.java
+++ b/src/main/java/in/koreatech/payment/client/dto/PaymentConfirmResponse.java
@@ -1,0 +1,8 @@
+package in.koreatech.payment.client.dto;
+
+public record PaymentConfirmResponse(
+    String paymentKey,
+    String orderId,
+    Integer amount
+) {
+}

--- a/src/main/java/in/koreatech/payment/client/dto/TossPaymentConfirmRequest.java
+++ b/src/main/java/in/koreatech/payment/client/dto/TossPaymentConfirmRequest.java
@@ -1,9 +1,0 @@
-package in.koreatech.payment.client.dto;
-
-public record TossPaymentConfirmRequest(
-    String paymentKey,
-    String orderId,
-    Integer amount
-) {
-
-}

--- a/src/main/java/in/koreatech/payment/client/dto/request/PaymentConfirmRequest.java
+++ b/src/main/java/in/koreatech/payment/client/dto/request/PaymentConfirmRequest.java
@@ -1,0 +1,9 @@
+package in.koreatech.payment.client.dto.request;
+
+public record PaymentConfirmRequest(
+    String paymentKey,
+    String orderId,
+    Integer amount
+) {
+
+}

--- a/src/main/java/in/koreatech/payment/client/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/in/koreatech/payment/client/dto/response/PaymentConfirmResponse.java
@@ -1,4 +1,4 @@
-package in.koreatech.payment.client.dto;
+package in.koreatech.payment.client.dto.response;
 
 public record PaymentConfirmResponse(
     String paymentKey,

--- a/src/main/java/in/koreatech/payment/model/Payment.java
+++ b/src/main/java/in/koreatech/payment/model/Payment.java
@@ -1,19 +1,15 @@
 package in.koreatech.payment.model;
 
-import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static java.lang.Boolean.FALSE;
 import static lombok.AccessLevel.PROTECTED;
 
-import java.math.BigDecimal;
+import org.hibernate.annotations.Where;
 
-import in.koreatech.koin.domain.user.model.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -25,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "payment")
+@Where(clause = "is_deleted=0")
 @NoArgsConstructor(access = PROTECTED)
 public class Payment {
 
@@ -47,20 +44,24 @@ public class Payment {
     @Column(name = "amount", nullable = false, updatable = false)
     private Integer amount;
 
-    @JoinColumn(name = "user_id")
-    @ManyToOne(fetch = LAZY)
-    private User user;
+    @NotNull
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Integer userId;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = FALSE;
 
     @Builder
     private Payment(
         String paymentKey,
         String orderId,
         Integer amount,
-        User user
+        Integer userId
     ) {
         this.paymentKey = paymentKey;
         this.orderId = orderId;
         this.amount = amount;
-        this.user = user;
+        this.userId = userId;
     }
 }

--- a/src/main/java/in/koreatech/payment/model/Payment.java
+++ b/src/main/java/in/koreatech/payment/model/Payment.java
@@ -1,0 +1,66 @@
+package in.koreatech.payment.model;
+
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.math.BigDecimal;
+
+import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "payment")
+@NoArgsConstructor(access = PROTECTED)
+public class Payment {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotBlank
+    @Size(max = 200)
+    @Column(name = "payment_key", length = 200, nullable = false, updatable = false)
+    private String paymentKey;
+
+    @NotBlank
+    @Size(min = 6, max = 64)
+    @Column(name = "order_id", length = 64, nullable = false, updatable = false)
+    private String orderId;
+
+    @NotNull
+    @Column(name = "amount", nullable = false, updatable = false)
+    private Integer amount;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @Builder
+    private Payment(
+        String paymentKey,
+        String orderId,
+        Integer amount,
+        User user
+    ) {
+        this.paymentKey = paymentKey;
+        this.orderId = orderId;
+        this.amount = amount;
+        this.user = user;
+    }
+}

--- a/src/main/java/in/koreatech/payment/repository/PaymentRepository.java
+++ b/src/main/java/in/koreatech/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.payment.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.payment.model.Payment;
+
+public interface PaymentRepository extends Repository<Payment, Integer> {
+
+    void save(Payment payment);
+}

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -6,8 +6,11 @@ import org.springframework.transaction.annotation.Transactional;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.payment.client.TossPaymentClient;
+import in.koreatech.payment.client.dto.PaymentConfirmResponse;
 import in.koreatech.payment.common.auth.JwtTokenResolver;
+import in.koreatech.payment.model.Payment;
 import in.koreatech.payment.model.TemporaryPayment;
+import in.koreatech.payment.repository.PaymentRepository;
 import in.koreatech.payment.repository.TemporaryPaymentRepository;
 import in.koreatech.payment.util.OrderIdGenerator;
 import lombok.RequiredArgsConstructor;
@@ -22,13 +25,15 @@ public class TossService implements PaymentService {
     private final JwtTokenResolver jwtTokenResolver;
     private final UserRepository userRepository;
     private final TossPaymentClient tossPaymentClient;
+    private final PaymentRepository paymentRepository;
 
     @Transactional
     public String createTemporaryPayment(String accessToken, Integer amount) {
         Integer userId = jwtTokenResolver.getUserId(accessToken);
         User user = userRepository.getById(userId);
         String orderId = orderIdGenerator.generateOrderId();
-        TemporaryPayment temporaryPayment = temporaryPaymentRepository.save(TemporaryPayment.of(orderId, user.getId(), amount));
+        TemporaryPayment temporaryPayment = temporaryPaymentRepository.save(
+            TemporaryPayment.of(orderId, user.getId(), amount));
         return temporaryPayment.getOrderId();
     }
 
@@ -38,7 +43,13 @@ public class TossService implements PaymentService {
         User user = userRepository.getById(userId);
         TemporaryPayment temporaryPayment = temporaryPaymentRepository.getByOrderId(orderId);
         temporaryPayment.validateMatches(orderId, user.getId(), amount);
-        tossPaymentClient.requestConfirm(paymentKey, orderId, amount);
-        // TODO. 응답값 파싱 후 로직 처리
+        PaymentConfirmResponse response = tossPaymentClient.requestConfirm(paymentKey, orderId, amount);
+        paymentRepository.save(Payment.builder()
+            .paymentKey(response.paymentKey())
+            .orderId(response.orderId())
+            .amount(response.amount())
+            .user(user)
+            .build());
+        temporaryPaymentRepository.deleteById(orderId);
     }
 }

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.payment.client.TossPaymentClient;
-import in.koreatech.payment.client.dto.PaymentConfirmResponse;
+import in.koreatech.payment.client.dto.response.PaymentConfirmResponse;
 import in.koreatech.payment.common.auth.JwtTokenResolver;
 import in.koreatech.payment.model.Payment;
 import in.koreatech.payment.model.TemporaryPayment;

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -48,7 +48,7 @@ public class TossService implements PaymentService {
             .paymentKey(response.paymentKey())
             .orderId(response.orderId())
             .amount(response.amount())
-            .user(user)
+            .userId(user.getId())
             .build());
         temporaryPaymentRepository.deleteById(orderId);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #18 

# 🚀 작업 내용
### Payment 파싱
- 스레드에서 요청 성공 응답값인 Payment를 모두 저장하는 것으로 이야기가 많이 나왔습니다.
- Payment 테이블이 꽤나 쉽지 않아질 거 같아서, 임시로 필수 정보만 저장하는 로직을 구현했습니다.
- 향후 Payment 응답값 확인이 가능해지면 추가 구현하겠습니다. (현재 paymentKey를 발급받을 수단이 없어서, Payment 응답값을 확인할 수 있는 수단이 안 보입니다.)

# 💬 리뷰 중점사항
클라이언트 분들이 사용 해야하니, 임시로 구현했습니다.

### TODO
- Redis 데이터 영속화
- Payment 저장 데이터 추가하기