### PR TITLE
feat: 결제 취소 API 구현

### DIFF
--- a/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
+++ b/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
@@ -69,7 +69,7 @@ public class TossPaymentClient {
 
         try {
             webClient.post()
-                .uri("{paymentKey}/cancel", paymentKey)
+                .uri("/{paymentKey}/cancel", paymentKey)
                 .header(IDEMPOTENT_KEY, IdempotencyKey)
                 .bodyValue(request)
                 .retrieve()

--- a/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
+++ b/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
@@ -14,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.koreatech.payment.client.dto.request.PaymentCancelRequest;
 import in.koreatech.payment.client.dto.request.PaymentConfirmRequest;
 import in.koreatech.payment.client.dto.response.PaymentConfirmResponse;
 import in.koreatech.payment.client.exception.TossPaymentErrorCode;
@@ -25,6 +26,7 @@ import in.koreatech.payment.common.exception.custom.KoinIllegalStateException;
 public class TossPaymentClient {
 
     private static final String AUTH_PREFIX = "Basic ";
+    private static final String IDEMPOTENT_KEY = "Idempotency-Key";
 
     private final WebClient webClient;
     private final String secretKey;
@@ -55,6 +57,24 @@ public class TossPaymentClient {
                 .bodyToMono(PaymentConfirmResponse.class)
                 .block();
 
+        } catch (WebClientResponseException e) {
+            throw handleErrorResponse(e);
+        } catch (Exception e) {
+            throw new KoinIllegalStateException("서버 에러가 발생했습니다. 관리자에게 문의해주세요.");
+        }
+    }
+
+    public void requestCancel(String paymentKey, String cancelReason, String IdempotencyKey) {
+        PaymentCancelRequest request = new PaymentCancelRequest(cancelReason);
+
+        try {
+            webClient.post()
+                .uri("{paymentKey}/cancel", paymentKey)
+                .header(IDEMPOTENT_KEY, IdempotencyKey)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
         } catch (WebClientResponseException e) {
             throw handleErrorResponse(e);
         } catch (Exception e) {

--- a/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
+++ b/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
@@ -14,10 +14,10 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.koreatech.payment.client.dto.response.PaymentConfirmResponse;
-import in.koreatech.payment.client.exception.TossPaymentErrorResponse;
 import in.koreatech.payment.client.dto.request.PaymentConfirmRequest;
+import in.koreatech.payment.client.dto.response.PaymentConfirmResponse;
 import in.koreatech.payment.client.exception.TossPaymentErrorCode;
+import in.koreatech.payment.client.exception.TossPaymentErrorResponse;
 import in.koreatech.payment.client.exception.TossPaymentException;
 import in.koreatech.payment.common.exception.custom.KoinIllegalStateException;
 

--- a/src/main/java/in/koreatech/payment/client/dto/request/PaymentCancelRequest.java
+++ b/src/main/java/in/koreatech/payment/client/dto/request/PaymentCancelRequest.java
@@ -1,0 +1,7 @@
+package in.koreatech.payment.client.dto.request;
+
+public record PaymentCancelRequest(
+    String cancelReason
+) {
+
+}

--- a/src/main/java/in/koreatech/payment/client/exception/TossPaymentErrorCode.java
+++ b/src/main/java/in/koreatech/payment/client/exception/TossPaymentErrorCode.java
@@ -62,7 +62,38 @@ public enum TossPaymentErrorCode {
     CARD_PROCESSING_ERROR("CARD_PROCESSING_ERROR", "카드사에서 오류가 발생했습니다.", 500),
     FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING("FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING", "결제가 완료되지 않았어요. 다시 시도해주세요.", 500),
     FAILED_INTERNAL_SYSTEM_PROCESSING("FAILED_INTERNAL_SYSTEM_PROCESSING", "내부 시스템 처리 작업이 실패했습니다. 잠시 후 다시 시도해주세요.", 500),
-    UNKNOWN_PAYMENT_ERROR("UNKNOWN_PAYMENT_ERROR", "결제에 실패했어요. 반복되면 카드사로 문의해주세요.", 500);
+    UNKNOWN_PAYMENT_ERROR("UNKNOWN_PAYMENT_ERROR", "결제에 실패했어요. 반복되면 카드사로 문의해주세요.", 500),
+
+    // 결제 취소 API 에러 코드
+    // 400
+    ALREADY_CANCELED_PAYMENT("ALREADY_CANCELED_PAYMENT", "이미 취소된 결제입니다.", 400),
+    INVALID_REFUND_ACCOUNT_INFO("INVALID_REFUND_ACCOUNT_INFO", "환불 계좌번호와 예금주명이 일치하지 않습니다.", 400),
+    EXCEED_CANCEL_AMOUNT_DISCOUNT_AMOUNT("EXCEED_CANCEL_AMOUNT_DISCOUNT_AMOUNT", "즉시할인금액보다 적은 금액은 부분취소가 불가능합니다.", 400),
+    INVALID_REFUND_ACCOUNT_NUMBER("INVALID_REFUND_ACCOUNT_NUMBER", "잘못된 환불 계좌번호입니다.", 400),
+    INVALID_BANK("INVALID_BANK", "유효하지 않은 은행입니다.", 400),
+    NOT_MATCHES_REFUNDABLE_AMOUNT("NOT_MATCHES_REFUNDABLE_AMOUNT", "작앵 결과가 일치하지 않습니다.", 400),
+    REFUND_REJECTED("REFUND_REJECTED", "환불이 거절됐습니다. 결제사에 문의부탁드립니다.", 400),
+    ALREADY_REFUND_PAYMENT("ALREADY_REFUND_PAYMENT", "이미 환불된 결제입니다.", 400),
+    FORBIDDEN_BANK_REFUND_REQUEST("FORBIDDEN_BANK_REFUND_REQUEST", "고객 계좌가 입금이 되지 않는 상태입니다.", 400),
+
+    // 403
+    NOT_CANCELABLE_AMOUNT("NOT_CANCELABLE_AMOUNT", "취소 할 수 없는 금액입니다.", 403),
+    FORBIDDEN_CONSECUTIVE_REQUEST("FORBIDDEN_CONSECUTIVE_REQUEST", "반복적인 요청은 허용되지 않습니다. 잠시 후 다시 시도해주세요.", 403),
+    NOT_CANCELABLE_PAYMENT("NOT_CANCELABLE_PAYMENT", "취소 할 수 없는 결제 입니다.", 403),
+    EXCEED_MAX_REFUND_DUE("EXCEED_MAX_REFUND_DUE", "환불 가능한 기간이 지났습니다.", 403),
+    NOT_ALLOWED_PARTIAL_REFUND_WAITING_DEPOSIT("NOT_ALLOWED_PARTIAL_REFUND_WAITING_DEPOSIT", "입금 대기중인 결제는 부분 환불이 불가능합니다.", 403),
+    NOT_ALLOWED_PARTIAL_REFUND("NOT_ALLOWED_PARTIAL_REFUND", "에스크로 주문, 현금 카드 결제일때는 부분 환불이 불가합니다. 이외 다른 결제 수단에서 부분취소가 되지 않을 때는 토스페이머츤에 문의해 주세요.", 403),
+    NOT_CANCELABLE_PAYMENT_FOR_DORMANT_USER("NOT_CANCELABLE_PAYMENT_FOR_DORMANT_USER", "휴먼 처리된 회원의 결제는 취소할 수 없습니다.", 403),
+
+    // 500 Internal Server Error
+    FAILED_INTERNAL_SYSETM_PROCESSING("FAILED_INTERNAL_SYSETM_PROCESSING", "내부 시스템 처리 작업이 실패했습니다. 잠시 후 다시 시도해주세요.", 500),
+    FAILD_REFUND_PROCESS("FAILD_REFUND_PROCESS", "은행 응답시간 지연이나 일시적인 오류로 환불요청에 실패했습니다.", 500),
+    FAILD_METHOD_HANDLING_CANCEL("FAILD_METHOD_HANDLING_CANCEL", "취소 중 결제 시 사용한 결제 수단 처리과정에서 일시적인 오류가 발생했습니다.", 500),
+    FAILD_PARTIAL_REFUND("FAILD_PARTIAL_REFUND", "은행 점검, 해약 계좌 등의 사유로 부분 환불이 실패했습니다.", 500),
+    COMMON_ERROR("COMMON_ERROR", "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", 500),
+    FAILED_PAYMENT_INTERNAL_SYSETM_PROCESSING("FAILED_PAYMENT_INTERNAL_SYSETM_PROCESSING", "결제가 완료되지 않았어요. 다시 시도해주세요.", 500),
+    FAILED_CLOSED_ACCOUNT_REFUND("FAILED_CLOSED_ACCOUNT_REFUND", "해약된 계좌로 인해 환불이 실패했습니다.", 500),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
@@ -1,5 +1,8 @@
 package in.koreatech.payment.common.config.dataSource;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -41,7 +44,16 @@ public class KoinPaymentDataSourceConfig {
         em.setDataSource(dataSource);
         em.setPackagesToScan("in.koreatech.payment");
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+        em.setJpaPropertyMap(hibernateProperties());
         return em;
+    }
+
+    private Map<String, Object> hibernateProperties() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("hibernate.hbm2ddl.auto", "create-drop");
+        props.put("hibernate.show_sql", true);
+        props.put("hibernate.format_sql", true);
+        return props;
     }
 
     @Primary

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
@@ -1,8 +1,5 @@
 package in.koreatech.payment.common.config.dataSource;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -44,16 +41,7 @@ public class KoinPaymentDataSourceConfig {
         em.setDataSource(dataSource);
         em.setPackagesToScan("in.koreatech.payment");
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
-        em.setJpaPropertyMap(hibernateProperties());
         return em;
-    }
-
-    private Map<String, Object> hibernateProperties() {
-        Map<String, Object> props = new HashMap<>();
-        props.put("hibernate.hbm2ddl.auto", "create-drop");
-        props.put("hibernate.show_sql", true);
-        props.put("hibernate.format_sql", true);
-        return props;
     }
 
     @Primary

--- a/src/main/java/in/koreatech/payment/controller/PaymentsApi.java
+++ b/src/main/java/in/koreatech/payment/controller/PaymentsApi.java
@@ -1,15 +1,18 @@
 package in.koreatech.payment.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import in.koreatech.payment.common.auth.AccessToken;
+import in.koreatech.payment.dto.request.PaymentCancelRequest;
 import in.koreatech.payment.dto.request.PaymentConfirmRequest;
 import in.koreatech.payment.dto.request.TemporaryPaymentInformationSaveRequest;
 import in.koreatech.payment.dto.response.TemporaryPaymentResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -82,6 +85,18 @@ public interface PaymentsApi {
     @PostMapping("/confirm")
     ResponseEntity<Void> confirmPayment(
         @RequestBody @Valid final PaymentConfirmRequest request,
+        @AccessToken final String accessToken
+    );
+
+    @Operation(
+        summary = "결제 취소를 한다.",
+        description = "결제 취소를 한다."
+    )
+    @PostMapping("/{paymentKey}/cancel")
+    ResponseEntity<Void> cancelPayment(
+        @Parameter(description = "결제 키", example = "5EnNZRJGvaBX7zk2yd8ydw26XvwXkLrx9POLqKQjmAw4b0e1")
+        @PathVariable(value = "paymentKey") final String paymentKey,
+        @RequestBody @Valid final PaymentCancelRequest request,
         @AccessToken final String accessToken
     );
 }

--- a/src/main/java/in/koreatech/payment/controller/PaymentsController.java
+++ b/src/main/java/in/koreatech/payment/controller/PaymentsController.java
@@ -1,12 +1,14 @@
 package in.koreatech.payment.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.payment.common.auth.AccessToken;
+import in.koreatech.payment.dto.request.PaymentCancelRequest;
 import in.koreatech.payment.dto.request.PaymentConfirmRequest;
 import in.koreatech.payment.dto.request.TemporaryPaymentInformationSaveRequest;
 import in.koreatech.payment.dto.response.TemporaryPaymentResponse;
@@ -37,6 +39,16 @@ public class PaymentsController implements PaymentsApi {
         @AccessToken final String accessToken
     ) {
         paymentService.confirmPayment(accessToken, request.paymentKey(), request.orderId(), request.amount());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{paymentKey}/cancel")
+    public ResponseEntity<Void> cancelPayment(
+        @PathVariable(value = "paymentKey") final String paymentKey,
+        @RequestBody @Valid final PaymentCancelRequest request,
+        @AccessToken final String accessToken
+    ) {
+        paymentService.cancelPayment(accessToken, paymentKey, request.cancelReason());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/payment/dto/request/PaymentCancelRequest.java
+++ b/src/main/java/in/koreatech/payment/dto/request/PaymentCancelRequest.java
@@ -1,0 +1,18 @@
+package in.koreatech.payment.dto.request;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record PaymentCancelRequest(
+    @Schema(description = "결제 취소 사유", example = "잘못 주문했어요.", requiredMode = REQUIRED)
+    @NotBlank(message = "결제 취소 사유는 필수 입력값입니다.")
+    String cancelReason
+) {
+
+}

--- a/src/main/java/in/koreatech/payment/exception/PaymentAccessDeniedException.java
+++ b/src/main/java/in/koreatech/payment/exception/PaymentAccessDeniedException.java
@@ -1,0 +1,21 @@
+package in.koreatech.payment.exception;
+
+import in.koreatech.payment.common.exception.custom.AuthorizationException;
+
+public class PaymentAccessDeniedException extends AuthorizationException {
+
+    private static final String DEFAULT_MESSAGE = "결제 정보 접근 권한이 없습니다.";
+    private static final String ERROR_CODE = "PAYMENT_ACCESS_DENIED";
+
+    public PaymentAccessDeniedException(String message) {
+        super(message, ERROR_CODE);
+    }
+
+    public PaymentAccessDeniedException(String message, String detail) {
+        super(message, detail, ERROR_CODE);
+    }
+
+    public static PaymentAccessDeniedException withDetail(String detail) {
+        return new PaymentAccessDeniedException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/payment/exception/PaymentNotFoundException.java
+++ b/src/main/java/in/koreatech/payment/exception/PaymentNotFoundException.java
@@ -1,0 +1,21 @@
+package in.koreatech.payment.exception;
+
+import in.koreatech.payment.common.exception.custom.DataNotFoundException;
+
+public class PaymentNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "결제 정보가 존재하지 않습니다.";
+    private static final String ERROR_CODE = "NOT_FOUND_PAYMENT";
+
+    public PaymentNotFoundException(String message) {
+        super(message, ERROR_CODE);
+    }
+
+    public PaymentNotFoundException(String message, String detail) {
+        super(message, detail, ERROR_CODE);
+    }
+
+    public static PaymentNotFoundException withDetail(String detail) {
+        return new PaymentNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/payment/model/Payment.java
+++ b/src/main/java/in/koreatech/payment/model/Payment.java
@@ -71,4 +71,6 @@ public class Payment {
             throw InvalidTemporaryPaymentException.withDetail("userId : " + userId);
         }
     }
+
+    // TODO. Payment 필드 추가, 결제 승인 및 취소 등 상태 변화 메소드 추가
 }

--- a/src/main/java/in/koreatech/payment/model/Payment.java
+++ b/src/main/java/in/koreatech/payment/model/Payment.java
@@ -6,6 +6,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 import org.hibernate.annotations.Where;
 
+import in.koreatech.payment.exception.InvalidTemporaryPaymentException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -63,5 +64,11 @@ public class Payment {
         this.orderId = orderId;
         this.amount = amount;
         this.userId = userId;
+    }
+
+    public void validateUserIdMatches(Integer userId) {
+        if (!userId.equals(this.userId)) {
+            throw InvalidTemporaryPaymentException.withDetail("userId : " + userId);
+        }
     }
 }

--- a/src/main/java/in/koreatech/payment/model/Payment.java
+++ b/src/main/java/in/koreatech/payment/model/Payment.java
@@ -7,6 +7,7 @@ import static lombok.AccessLevel.PROTECTED;
 import org.hibernate.annotations.Where;
 
 import in.koreatech.payment.exception.InvalidTemporaryPaymentException;
+import in.koreatech.payment.exception.PaymentAccessDeniedException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -68,7 +69,7 @@ public class Payment {
 
     public void validateUserIdMatches(Integer userId) {
         if (!userId.equals(this.userId)) {
-            throw InvalidTemporaryPaymentException.withDetail("userId : " + userId);
+            throw PaymentAccessDeniedException.withDetail("userId : " + userId);
         }
     }
 

--- a/src/main/java/in/koreatech/payment/model/PaymentIdempotencyKey.java
+++ b/src/main/java/in/koreatech/payment/model/PaymentIdempotencyKey.java
@@ -3,6 +3,7 @@ package in.koreatech.payment.model;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import in.koreatech.payment.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
     uniqueConstraints = @UniqueConstraint(name = "uk_idempotency_key_user_id", columnNames = "user_id")
 )
 @NoArgsConstructor(access = PROTECTED)
-public class PaymentIdempotencyKey {
+public class PaymentIdempotencyKey extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/in/koreatech/payment/model/PaymentIdempotencyKey.java
+++ b/src/main/java/in/koreatech/payment/model/PaymentIdempotencyKey.java
@@ -1,0 +1,48 @@
+package in.koreatech.payment.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    name = "payment_idempotency_key",
+    uniqueConstraints = @UniqueConstraint(name = "uk_idempotency_key_user_id", columnNames = "user_id")
+)
+@NoArgsConstructor(access = PROTECTED)
+public class PaymentIdempotencyKey {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Integer userId;
+
+    @NotNull
+    @Size(max = 300)
+    @Column(name = "idempotency_key", nullable = false, length = 300)
+    private String idempotencyKey;
+
+    @Builder
+    private PaymentIdempotencyKey(
+        Integer userId,
+        String idempotencyKey
+    ) {
+        this.userId = userId;
+        this.idempotencyKey = idempotencyKey;
+    }
+}

--- a/src/main/java/in/koreatech/payment/model/PaymentIdempotencyKey.java
+++ b/src/main/java/in/koreatech/payment/model/PaymentIdempotencyKey.java
@@ -3,6 +3,9 @@ package in.koreatech.payment.model;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import in.koreatech.payment.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,6 +28,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class PaymentIdempotencyKey extends BaseEntity {
 
+    private static final int EXPIRE_DAYS = 15;
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Integer id;
@@ -45,5 +50,13 @@ public class PaymentIdempotencyKey extends BaseEntity {
     ) {
         this.userId = userId;
         this.idempotencyKey = idempotencyKey;
+    }
+
+    public void updateIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public boolean isOlderThanExpireDays() {
+        return ChronoUnit.DAYS.between(super.getUpdatedAt(), LocalDateTime.now()) >= EXPIRE_DAYS;
     }
 }

--- a/src/main/java/in/koreatech/payment/repository/PaymentIdempotencyKeyRepository.java
+++ b/src/main/java/in/koreatech/payment/repository/PaymentIdempotencyKeyRepository.java
@@ -1,0 +1,14 @@
+package in.koreatech.payment.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.payment.model.PaymentIdempotencyKey;
+
+public interface PaymentIdempotencyKeyRepository extends Repository<PaymentIdempotencyKey, Integer> {
+
+    PaymentIdempotencyKey save(PaymentIdempotencyKey paymentIdempotencyKey);
+
+    Optional<PaymentIdempotencyKey> findByUserId(Integer userId);
+}

--- a/src/main/java/in/koreatech/payment/repository/PaymentRepository.java
+++ b/src/main/java/in/koreatech/payment/repository/PaymentRepository.java
@@ -1,10 +1,20 @@
 package in.koreatech.payment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.payment.exception.PaymentNotFoundException;
 import in.koreatech.payment.model.Payment;
 
 public interface PaymentRepository extends Repository<Payment, Integer> {
 
     void save(Payment payment);
+
+    Optional<Payment> findByPaymentKey(String paymentKey);
+
+    default Payment getByPaymentKey(String paymentKey) {
+        return findByPaymentKey(paymentKey)
+            .orElseThrow(() -> PaymentNotFoundException.withDetail("paymentKey : " + paymentKey));
+    }
 }

--- a/src/main/java/in/koreatech/payment/service/PaymentService.java
+++ b/src/main/java/in/koreatech/payment/service/PaymentService.java
@@ -3,4 +3,5 @@ package in.koreatech.payment.service;
 public interface PaymentService {
     String createTemporaryPayment(String accessToken, Integer amount);
     void confirmPayment(String accessToken, String paymentKey, String orderId, Integer amount);
+    void cancelPayment(String accessToken, String paymentKey, String cancelReason);
 }

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -1,5 +1,7 @@
 package in.koreatech.payment.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,7 +11,9 @@ import in.koreatech.payment.client.TossPaymentClient;
 import in.koreatech.payment.client.dto.response.PaymentConfirmResponse;
 import in.koreatech.payment.common.auth.JwtTokenResolver;
 import in.koreatech.payment.model.Payment;
+import in.koreatech.payment.model.PaymentIdempotencyKey;
 import in.koreatech.payment.model.TemporaryPayment;
+import in.koreatech.payment.repository.PaymentIdempotencyKeyRepository;
 import in.koreatech.payment.repository.PaymentRepository;
 import in.koreatech.payment.repository.TemporaryPaymentRepository;
 import in.koreatech.payment.util.OrderIdGenerator;
@@ -26,6 +30,7 @@ public class TossService implements PaymentService {
     private final UserRepository userRepository;
     private final TossPaymentClient tossPaymentClient;
     private final PaymentRepository paymentRepository;
+    private final PaymentIdempotencyKeyRepository paymentIdempotencyKeyRepository;
 
     @Transactional
     public String createTemporaryPayment(String accessToken, Integer amount) {
@@ -59,6 +64,21 @@ public class TossService implements PaymentService {
         User user = userRepository.getById(userId);
         Payment payment = paymentRepository.getByPaymentKey(paymentKey);
         payment.validateUserIdMatches(user.getId());
-        
+        PaymentIdempotencyKey paymentIdempotencyKey = paymentIdempotencyKeyRepository
+            .findByUserId(user.getId())
+            .map(idempotencyKey -> {
+                if (idempotencyKey.isOlderThanExpireDays()) {
+                    idempotencyKey.updateIdempotencyKey(UUID.randomUUID().toString());
+                }
+                return idempotencyKey;
+            })
+            .orElseGet(() -> paymentIdempotencyKeyRepository.save(
+                PaymentIdempotencyKey.builder()
+                    .userId(user.getId())
+                    .idempotencyKey(UUID.randomUUID().toString())
+                    .build()
+            ));
+
+        tossPaymentClient.requestCancel(paymentKey, cancelReason, paymentIdempotencyKey.getIdempotencyKey());
     }
 }

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -52,4 +52,13 @@ public class TossService implements PaymentService {
             .build());
         temporaryPaymentRepository.deleteById(orderId);
     }
+
+    @Transactional
+    public void cancelPayment(String accessToken, String paymentKey, String cancelReason) {
+        Integer userId = jwtTokenResolver.getUserId(accessToken);
+        User user = userRepository.getById(userId);
+        Payment payment = paymentRepository.getByPaymentKey(paymentKey);
+        payment.validateUserIdMatches(user.getId());
+        
+    }
 }

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -80,5 +80,6 @@ public class TossService implements PaymentService {
             ));
 
         tossPaymentClient.requestCancel(paymentKey, cancelReason, paymentIdempotencyKey.getIdempotencyKey());
+        // TODO. Payment 필드 추가 후 로직 추가
     }
 }

--- a/src/main/java/in/koreatech/payment/util/TossPaymentOrderIdGenerator.java
+++ b/src/main/java/in/koreatech/payment/util/TossPaymentOrderIdGenerator.java
@@ -5,7 +5,7 @@ import java.security.SecureRandom;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TossPaymentOrderIdGenerator implements OrderIdGenerator{
+public class TossPaymentOrderIdGenerator implements OrderIdGenerator {
 
     private static final String ORDER_ID_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
     private static final int ORDER_ID_MIN_LENGTH = 6;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #20 

# 🚀 작업 내용
### 결제 취소 API 구현
- 결제 취소 API를 구현했습니다.
  - path으로 paymentKey를 받고, body으로 cancelReason을 받습니다. [API 설명](https://docs.tosspayments.com/reference#%EA%B2%B0%EC%A0%9C-%EC%B7%A8%EC%86%8C)
  - 결제 취소의 경우 멱등키를 헤더로 추가를 해야하기 때문에 user와 1:1 테이블을 만들었습니다. [멱등키 설명](https://docs.tosspayments.com/reference/using-api/authorization#%EB%A9%B1%EB%93%B1%ED%82%A4-%ED%97%A4%EB%8D%94)
    - 15일마다 갱신을 요구하기 때문에, 요청 시 15일이 지난 경우 새롭게 업데이트합니다.
  - 에러 코드는 [다음](https://www.notion.so/20d9ae650b59802bb7f5fc7e64cdde6b?source=copy_link)과 같습니다.

# 💬 리뷰 중점사항
### TODO
- Payment 테이블 다시 구현
- 멀티 데이터 소스 설정 수정