### PR TITLE
fix: 멀티 데이터 소스 설정 변경

### DIFF
--- a/src/main/java/in/koreatech/payment/KoinPaymentApplication.java
+++ b/src/main/java/in/koreatech/payment/KoinPaymentApplication.java
@@ -2,8 +2,10 @@ package in.koreatech.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class KoinPaymentApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDBProperties.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDBProperties.java
@@ -1,0 +1,11 @@
+package in.koreatech.payment.common.config.dataSource;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.datasource.koin.hibernate")
+public record KoinDBProperties(
+    String ddlAuto,
+    Boolean showSql,
+    String packagesToScan
+) {
+}

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDBProperties.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDBProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record KoinDBProperties(
     String ddlAuto,
     Boolean showSql,
-    String packagesToScan
+    String packagesToScan,
+    String formatSql
 ) {
 }

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDataSourceConfig.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDataSourceConfig.java
@@ -54,6 +54,7 @@ public class KoinDataSourceConfig {
         Map<String, Object> properties = new HashMap<>();
         properties.put("hibernate.show_sql", koinDBProperties.showSql());
         properties.put("hibernate.hbm2ddl.auto", koinDBProperties.ddlAuto());
+        properties.put("hibernate.format_sql", koinDBProperties.formatSql());
         return properties;
     }
 

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDataSourceConfig.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinDataSourceConfig.java
@@ -1,5 +1,8 @@
 package in.koreatech.payment.common.config.dataSource;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -15,8 +18,10 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableTransactionManagement
 @EnableJpaRepositories(
     basePackages = "in.koreatech.koin",
@@ -24,6 +29,8 @@ import jakarta.persistence.EntityManagerFactory;
     transactionManagerRef = "koinTransactionManager"
 )
 public class KoinDataSourceConfig {
+
+    private final KoinDBProperties koinDBProperties;
 
     @Bean(name = "koinDataSource")
     @ConfigurationProperties("spring.datasource.koin")
@@ -37,9 +44,17 @@ public class KoinDataSourceConfig {
     ) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setDataSource(dataSource);
-        em.setPackagesToScan("in.koreatech.koin");
+        em.setPackagesToScan(koinDBProperties.packagesToScan());
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+        em.setJpaPropertyMap(createJpaVendorProperties());
         return em;
+    }
+
+    private Map<String, Object> createJpaVendorProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.show_sql", koinDBProperties.showSql());
+        properties.put("hibernate.hbm2ddl.auto", koinDBProperties.ddlAuto());
+        return properties;
     }
 
     @Bean(name = "koinTransactionManager")

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDBProperties.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDBProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record KoinPaymentDBProperties(
     String ddlAuto,
     Boolean showSql,
-    String packagesToScan
+    String packagesToScan,
+    String formatSql
 ) {
 }

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDBProperties.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDBProperties.java
@@ -1,0 +1,11 @@
+package in.koreatech.payment.common.config.dataSource;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.datasource.koin-payment.hibernate")
+public record KoinPaymentDBProperties(
+    String ddlAuto,
+    Boolean showSql,
+    String packagesToScan
+) {
+}

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
@@ -56,6 +56,7 @@ public class KoinPaymentDataSourceConfig {
         Map<String, Object> properties = new HashMap<>();
         properties.put("hibernate.show_sql", koinPaymentDBProperties.showSql());
         properties.put("hibernate.hbm2ddl.auto", koinPaymentDBProperties.ddlAuto());
+        properties.put("hibernate.format_sql", koinPaymentDBProperties.formatSql());
         return properties;
     }
 

--- a/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
+++ b/src/main/java/in/koreatech/payment/common/config/dataSource/KoinPaymentDataSourceConfig.java
@@ -1,5 +1,8 @@
 package in.koreatech.payment.common.config.dataSource;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -16,8 +19,10 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableTransactionManagement
 @EnableJpaRepositories(
     basePackages = "in.koreatech.payment",
@@ -25,6 +30,8 @@ import jakarta.persistence.EntityManagerFactory;
     transactionManagerRef = "koinPaymentTransactionManager"
 )
 public class KoinPaymentDataSourceConfig {
+
+    private final KoinPaymentDBProperties koinPaymentDBProperties;
 
     @Bean(name = "koinPaymentDataSource")
     @ConfigurationProperties("spring.datasource.koin-payment")
@@ -39,9 +46,17 @@ public class KoinPaymentDataSourceConfig {
     ) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setDataSource(dataSource);
-        em.setPackagesToScan("in.koreatech.payment");
+        em.setPackagesToScan(koinPaymentDBProperties.packagesToScan());
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+        em.setJpaPropertyMap(createJpaVendorProperties());
         return em;
+    }
+
+    private Map<String, Object> createJpaVendorProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.show_sql", koinPaymentDBProperties.showSql());
+        properties.put("hibernate.hbm2ddl.auto", koinPaymentDBProperties.ddlAuto());
+        return properties;
     }
 
     @Primary


### PR DESCRIPTION
# 🔥 연관 이슈

- close #24 

# 🚀 작업 내용
### 멀티 데이터 소스 설정 변경
- 멀티 데이터 소스의 jpa 설정을 환경변수에서 주입 받도록 수정했습니다.
- 기존에는 koin-payment가 primary으로 설정되어 있어, 해당 데이터 소스에만 jpa 설정이 걸렸습니다.
```
  datasource:
    koin-payment:
      driver-class-name: com.mysql.cj.jdbc.Driver
      jdbc-url: 
      username:
      password:
      hibernate:
        packages-to-scan: in.koreatech.payment
        ddl-auto: create-drop
        show-sql: false
        format_sql: false

    koin:
      driver-class-name: com.mysql.cj.jdbc.Driver
      jdbc-url: 
      username:
      password:
      hibernate:
        packages-to-scan: in.koreatech.koin
        ddl-auto: none
        show-sql: false
        format_sql: false
```

# 💬 리뷰 중점사항
