### PR TITLE
feat: 상점 관련 엔티티 클래스 추가

### DIFF
--- a/src/main/java/in/koreatech/common/converter/LocalTimeAttributeConverter.java
+++ b/src/main/java/in/koreatech/common/converter/LocalTimeAttributeConverter.java
@@ -1,0 +1,27 @@
+package in.koreatech.common.converter;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class LocalTimeAttributeConverter implements AttributeConverter<LocalTime, String> {
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+    @Override
+    public String convertToDatabaseColumn(LocalTime localTime) {
+        if (localTime == null)
+            return null;
+        return localTime.format(formatter);
+    }
+
+    @Override
+    public LocalTime convertToEntityAttribute(String dbData) {
+        if (dbData == null)
+            return null;
+        return LocalTime.parse(dbData, formatter);
+    }
+}

--- a/src/main/java/in/koreatech/koin/common/converter/LocalTimeAttributeConverter.java
+++ b/src/main/java/in/koreatech/koin/common/converter/LocalTimeAttributeConverter.java
@@ -1,4 +1,4 @@
-package in.koreatech.common.converter;
+package in.koreatech.koin.common.converter;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
@@ -1,0 +1,48 @@
+package in.koreatech.koin.domain.order.cart.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "cart")
+@NoArgsConstructor(access = PROTECTED)
+public class Cart extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_id", nullable = false)
+    private OrderableShop orderableShop;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<CartMenuItem> cartMenuItems = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItem.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItem.java
@@ -1,0 +1,57 @@
+package in.koreatech.koin.domain.order.cart.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenu;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuPrice;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "cart_menu_item")
+@NoArgsConstructor(access = PROTECTED)
+public class CartMenuItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false, unique = true)
+    private Cart cart;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_id", nullable = false)
+    private OrderableShopMenu orderableShopMenu;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_price_id", nullable = false)
+    private OrderableShopMenuPrice orderableShopMenuPrice;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "is_modified", nullable = false)
+    private Boolean isModified;
+
+    @OneToMany(mappedBy = "cartMenuItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartMenuItemOption> cartMenuItemOptions = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItemOption.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItemOption.java
@@ -1,0 +1,50 @@
+package in.koreatech.koin.domain.order.cart.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOption;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "cart_menu_item_option")
+@NoArgsConstructor(access = PROTECTED)
+public class CartMenuItemOption extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_menu_item_id", nullable = false)
+    private CartMenuItem cartMenuItem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_option_id", nullable = false)
+    private OrderableShopMenuOption orderableShopMenuOption;
+
+    @Column(name = "option_name", nullable = false)
+    private String optionName;
+
+    @Column(name = "option_price", nullable = false)
+    private Integer optionPrice;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "is_modified", nullable = false)
+    private Boolean isModified;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/OrderableShopMenuOptions.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/OrderableShopMenuOptions.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.domain.order.cart.model;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.List;
+import java.util.Map;
+
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOption;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderableShopMenuOptions {
+
+    private List<OrderableShopMenuOption> options;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/OrderableShopMenus.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/OrderableShopMenus.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.domain.order.cart.model;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenu;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderableShopMenus {
+
+    private Integer orderableShopId;
+    private List<OrderableShopMenu> menuList;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+public record OrderableShopInfoSummary(
+    Integer shopId,
+    Integer orderableShopId,
+    String name,
+    String introduction,
+    Boolean isDeliveryAvailable,
+    Boolean isTakeoutAvailable,
+    Boolean payCard,
+    Boolean payBank,
+    Integer minimumOrderAmount,
+    Double ratingAverage,
+    Integer reviewCount,
+    Integer minimumDeliveryTip,
+    Integer maximumDeliveryTip
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTipRange.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTipRange.java
@@ -1,0 +1,9 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+public record ShopBaseDeliveryTipRange(
+    Integer fromAmount,
+    Integer toAmount,
+    Integer fee
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTips.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTips.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+import static jakarta.persistence.CascadeType.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import in.koreatech.koin.domain.order.shop.model.entity.delivery.ShopBaseDeliveryTip;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+public class ShopBaseDeliveryTips {
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<ShopBaseDeliveryTip> baseDeliveryTips = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopMenuOrigins.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopMenuOrigins.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+import static jakarta.persistence.CascadeType.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import in.koreatech.koin.domain.shop.model.menu.MenuOrigin;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Embeddable
+@RequiredArgsConstructor
+public class ShopMenuOrigins {
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<MenuOrigin> origin = new ArrayList<>();
+
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/ShopBaseDeliveryTip.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/ShopBaseDeliveryTip.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.domain.order.shop.model.entity.delivery;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shop_base_delivery_tip")
+@Where(clause = "is_deleted=0")
+public class ShopBaseDeliveryTip extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
+    private Shop shop;
+
+    @Column(name = "order_amount", nullable = false)
+    private Integer orderAmount;
+
+    @Column(name = "fee", nullable = false)
+    private Integer fee;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenu.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenu.java
@@ -1,0 +1,67 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "orderable_shop_menu")
+@Where(clause = "is_deleted=0")
+public class OrderableShopMenu extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_id", referencedColumnName = "id", nullable = false)
+    private OrderableShop orderableShop;
+
+    @NotNull
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "text")
+    private String description;
+
+    @NotNull
+    @Column(name = "is_sold_out", nullable = false)
+    private Boolean isSoldOut = false;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderableShopMenuOptionGroupMap> menuOptionGroupMap = new ArrayList<>();
+
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderableShopMenuPrice> menuPrices = new ArrayList<>();
+
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderableShopMenuImage> menuImages = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuGroup.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuGroup.java
@@ -1,0 +1,50 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "orderable_shop_menu_group")
+@Where(clause = "is_deleted=0")
+public class OrderableShopMenuGroup extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_id", nullable = false)
+    private OrderableShop orderableShop;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @OneToMany(mappedBy = "menuGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderableShopMenuGroupMap> menuGroupMap = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuGroupMap.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuGroupMap.java
@@ -1,0 +1,42 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "orderable_shop_menu_group_map")
+@Where(clause = "is_deleted=0")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderableShopMenuGroupMap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_group_id", nullable = false)
+    private OrderableShopMenuGroup menuGroup;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_id", nullable = false)
+    private OrderableShopMenu menu;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuImage.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuImage.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "orderable_shop_menu_images")
+@Where(clause = "is_deleted=0")
+public class OrderableShopMenuImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_id", nullable = false)
+    private OrderableShopMenu menu;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "is_thumbnail", nullable = false)
+    private Boolean isThumbnail = false;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOption.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOption.java
@@ -1,0 +1,44 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "orderable_shop_menu_option")
+@Where(clause = "is_deleted=0")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderableShopMenuOption extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_option_group_id", nullable = false)
+    private OrderableShopMenuOptionGroup optionGroup;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroup.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroup.java
@@ -1,0 +1,62 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "orderable_shop_menu_option_group")
+@Where(clause = "is_deleted=0")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderableShopMenuOptionGroup extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_id", nullable = false)
+    private OrderableShop orderableShop;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "text")
+    private String description;
+
+    @Column(name = "is_required", nullable = false)
+    private Boolean isRequired = false;
+
+    @Column(name = "min_select", nullable = false)
+    private Integer minSelect = 0;
+
+    @Column(name = "max_select")
+    private Integer maxSelect;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @OneToMany(mappedBy = "optionGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderableShopMenuOption> menuOptions = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroupMap.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroupMap.java
@@ -1,0 +1,42 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "orderable_shop_menu_option_group_map")
+@Where(clause = "is_deleted=0")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderableShopMenuOptionGroupMap {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_option_group_id", nullable = false)
+    private OrderableShopMenuOptionGroup optionGroup;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_id", nullable = false)
+    private OrderableShopMenu menu;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuPrice.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuPrice.java
@@ -1,0 +1,44 @@
+package in.koreatech.koin.domain.order.shop.model.entity.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "orderable_shop_menu_price")
+@Where(clause = "is_deleted=0")
+public class OrderableShopMenuPrice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_menu_id", nullable = false)
+    private OrderableShopMenu menu;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -1,0 +1,63 @@
+package in.koreatech.koin.domain.order.shop.model.entity.shop;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuGroup;
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "orderable_shop")
+@Where(clause = "is_deleted=0")
+public class OrderableShop extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false, unique = true)
+    private Shop shop;
+
+    @Column(name = "delivery", nullable = false)
+    private boolean delivery = true;
+
+    @Column(name = "takeout", nullable = false)
+    private boolean takeout = true;
+
+    @Column(name = "service_event", nullable = false)
+    private boolean serviceEvent = false;
+
+    @Column(name = "minimum_order_amount", nullable = false)
+    private Integer minimumOrderAmount;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    @BatchSize(size = 7) // 기본 4개 (메인, 추천, 세트, 사이드) + 사장님 커스텀 3개
+    @OneToMany(mappedBy = "orderableShop", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderableShopMenuGroup> menuGroups = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/ShopOperation.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/ShopOperation.java
@@ -1,0 +1,41 @@
+package in.koreatech.koin.domain.order.shop.model.entity.shop;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shop_operation")
+@Where(clause = "is_deleted=0")
+public class ShopOperation {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false, unique = true)
+    private Shop shop;
+
+    @Column(name = "is_open", nullable = false)
+    private boolean isOpen = false;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/event/EventArticle.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/event/EventArticle.java
@@ -1,0 +1,85 @@
+package in.koreatech.koin.domain.shop.model.event;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event_articles")
+@Where(clause = "is_deleted=0")
+@SQLDelete(sql = "UPDATE event_articles SET is_deleted = true WHERE id = ?")
+@NoArgsConstructor(access = PROTECTED)
+public class EventArticle extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @OneToMany(mappedBy = "eventArticle", orphanRemoval = true, cascade = ALL)
+    private List<EventArticleImage> thumbnailImages = new ArrayList<>();
+
+    @NotNull
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @NotNull
+    @Column(name = "hit", nullable = false)
+    private Integer hit;
+
+    @Size(max = 45)
+    @NotNull
+    @Column(name = "ip", nullable = false)
+    private String ip;
+
+    @NotNull
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @NotNull
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/event/EventArticleImage.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/event/EventArticleImage.java
@@ -1,0 +1,39 @@
+package in.koreatech.koin.domain.shop.model.event;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event_article_thumbnail_images")
+@NoArgsConstructor(access = PROTECTED)
+public class EventArticleImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private EventArticle eventArticle;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "thumbnail_image")
+    private String thumbnailImage;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/Menu.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/Menu.java
@@ -1,0 +1,65 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menus")
+@NoArgsConstructor(access = PROTECTED)
+public class Menu extends BaseEntity {
+
+    private static final int SINGLE_OPTION_COUNT = 1;
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", referencedColumnName = "id", nullable = false)
+    private Shop shop;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Size(max = 255)
+    @Column(name = "description")
+    private String description;
+
+    @NotNull
+    @Column(name = "is_hidden", nullable = false)
+    private boolean isHidden = false;
+
+    @OneToMany(mappedBy = "menu", orphanRemoval = true, cascade = ALL)
+    private List<MenuCategoryMap> menuCategoryMaps = new ArrayList<>();
+
+    @OneToMany(mappedBy = "menu", orphanRemoval = true, cascade = ALL)
+    private List<MenuOption> menuOptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "menu", orphanRemoval = true, cascade = ALL)
+    private List<MenuImage> menuImages = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuCategory.java
@@ -1,0 +1,64 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menu_categories")
+@NoArgsConstructor(access = PROTECTED)
+public class MenuCategory extends BaseEntity implements Comparable<MenuCategory> {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
+    private Shop shop;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "menuCategory", orphanRemoval = true, cascade = ALL)
+    private List<MenuCategoryMap> menuCategoryMaps = new ArrayList<>();
+
+    @Transient
+    private Map<String, Integer> priorityMap = Map.of(
+        "추천 메뉴", 1,
+        "메인 메뉴", 2,
+        "세트 메뉴", 3,
+        "사이드 메뉴", 4
+    );
+
+    @Override
+    public int compareTo(MenuCategory other) {
+        return priorityMap.getOrDefault(name, 5) - priorityMap.getOrDefault(other.name, 5);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuCategoryMap.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuCategoryMap.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menu_category_map", uniqueConstraints = {
+    @UniqueConstraint(
+        name = "SHOP_MENU_ID_AND_SHOP_MENU_CATEGORY_ID",
+        columnNames = {"shop_menu_id", "shop_menu_category_id"}
+    )}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class MenuCategoryMap {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_menu_id")
+    private Menu menu;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_menu_category_id")
+    private MenuCategory menuCategory;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuImage.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuImage.java
@@ -1,0 +1,44 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menu_images", uniqueConstraints = {
+    @UniqueConstraint(
+        name = "SHOP_MENU_ID_AND_IMAGE_URL",
+        columnNames = {"shop_menu_id", "image_url"}
+    )}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class MenuImage {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "shop_menu_id")
+    private Menu menu;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOption.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOption.java
@@ -1,0 +1,50 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menu_details", uniqueConstraints = {
+    @UniqueConstraint(
+        name = "SHOP_MENU_ID_AND_OPTION_AND_PRICE",
+        columnNames = {"shop_menu_id", "option", "price"}
+    )}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class MenuOption extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_menu_id")
+    private Menu menu;
+
+    @Size(max = 255)
+    @Column(name = "`option`")
+    private String option;
+
+    @NotNull
+    @Column(name = "price", nullable = false)
+    @PositiveOrZero
+    private Integer price;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOrigin.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOrigin.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menu_origin")
+@NoArgsConstructor(access = PROTECTED)
+public class MenuOrigin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
+    private Shop shop;
+
+    @Column(name = "ingredient")
+    private String ingredient;
+
+    @Column(name = "origin")
+    private String origin;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuSearchKeyWord.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuSearchKeyWord.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menu_search_keywords")
+@NoArgsConstructor(access = PROTECTED)
+public class MenuSearchKeyWord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "keyword", nullable = false)
+    private String keyword;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/review/ReportStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/review/ReportStatus.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.domain.shop.model.review;
+
+public enum ReportStatus {
+    UNHANDLED("UNHANDLED", "처리 안함"),
+    DISMISSED("DISMISSED", "무의미한 신고여서 관련 리뷰 유지"),
+    DELETED("DELETED", "유의미한 신고여서 관련 리뷰 삭제"),
+    ;
+
+    private final String value;
+    private final String description;
+
+    ReportStatus(String value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReview.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReview.java
@@ -1,0 +1,58 @@
+package in.koreatech.koin.domain.shop.model.review;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_reviews")
+@NoArgsConstructor(access = PROTECTED)
+public class ShopReview extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(nullable = false)
+    private Integer rating;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
+    private Shop shop;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    @OneToMany(mappedBy = "review", orphanRemoval = true, cascade = ALL, fetch = LAZY)
+    private List<ShopReviewImage> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review", orphanRemoval = true, cascade = ALL, fetch = LAZY)
+    private List<ShopReviewMenu> menus = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review", orphanRemoval = true, cascade = ALL, fetch = LAZY)
+    private List<ShopReviewReport> reports = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewImage.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewImage.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.domain.shop.model.review;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_review_images")
+@NoArgsConstructor(access = PROTECTED)
+public class ShopReviewImage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private ShopReview review;
+
+    @Column(name = "image_urls", nullable = false)
+    private String imageUrls;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewMenu.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewMenu.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.domain.shop.model.review;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_review_menus")
+@NoArgsConstructor(access = PROTECTED)
+public class ShopReviewMenu extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private ShopReview review;
+
+    @Column(name = "menu_name", nullable = false)
+    private String menuName;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewReport.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewReport.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.domain.shop.model.review;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_review_reports")
+@NoArgsConstructor(access = PROTECTED)
+public class ShopReviewReport extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private ShopReview review;
+
+    @Column(name = "title", nullable = false, length = 50)
+    private String title;
+
+    @Column(name = "content", nullable = false, length = 255)
+    private String content;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 25)
+    private ReportStatus reportStatus;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewReportCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/review/ShopReviewReportCategory.java
@@ -1,0 +1,29 @@
+package in.koreatech.koin.domain.shop.model.review;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_review_reports_categories")
+@NoArgsConstructor(access = PROTECTED)
+public class ShopReviewReportCategory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "detail", nullable = false, length = 255)
+    private String detail;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -1,0 +1,154 @@
+package in.koreatech.koin.domain.shop.model.shop;
+
+import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.shop.model.event.EventArticle;
+import in.koreatech.koin.domain.shop.model.menu.Menu;
+import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
+import in.koreatech.koin.domain.shop.model.review.ShopReview;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shops")
+@Where(clause = "is_deleted=0")
+public class Shop extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", referencedColumnName = "user_id")
+    private Owner owner;
+
+    @Size(max = 50)
+    @NotNull
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Size(max = 50)
+    @NotNull
+    @Column(name = "internal_name", nullable = false, length = 50)
+    private String internalName;
+
+    @Size(max = 3)
+    @Column(name = "chosung", length = 3)
+    private String chosung;
+
+    @Size(max = 50)
+    @Column(name = "phone", length = 50)
+    private String phone;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "description")
+    private String description;
+
+    @NotNull
+    @Column(name = "delivery", nullable = false)
+    private Boolean delivery = false;
+
+    @NotNull
+    @Column(name = "delivery_price", nullable = false)
+    @PositiveOrZero
+    private Integer deliveryPrice;
+
+    @NotNull
+    @Column(name = "pay_card", nullable = false)
+    private boolean payCard = false;
+
+    @NotNull
+    @Column(name = "pay_bank", nullable = false)
+    private boolean payBank = false;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    @NotNull
+    @Column(name = "is_event", nullable = false)
+    private boolean isEvent = false;
+
+    @Column(name = "remarks")
+    private String remarks;
+
+    @NotNull
+    @Column(name = "hit", nullable = false)
+    private Integer hit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_category_id", referencedColumnName = "id")
+    private ShopCategory shopMainCategory;
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private Set<ShopCategoryMap> shopCategories = new HashSet<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<ShopOpen> shopOpens = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<ShopImage> shopImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<Menu> menus = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<MenuCategory> menuCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<EventArticle> eventArticles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<ShopReview> reviews = new ArrayList<>();
+
+    @OneToOne(mappedBy = "shop", fetch = FetchType.LAZY)
+    private ShopOperation shopOperation;
+
+    @Embedded
+    private ShopBaseDeliveryTips baseDeliveryTips = new ShopBaseDeliveryTips();
+
+    @Embedded
+    private ShopMenuOrigins menuOrigins = new ShopMenuOrigins();
+
+    @Size(max = 10)
+    @Column(name = "bank", length = 10)
+    private String bank;
+
+    @Size(max = 20)
+    @Column(name = "account_number", length = 20)
+    private String accountNumber;
+
+    @Column(name = "introduction", columnDefinition = "text")
+    private String introduction;
+
+    @Column(name = "notice", columnDefinition = "text")
+    private String notice;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -11,6 +11,9 @@ import java.util.Set;
 
 import org.hibernate.annotations.Where;
 
+import in.koreatech.koin.domain.order.shop.model.domain.ShopBaseDeliveryTips;
+import in.koreatech.koin.domain.order.shop.model.domain.ShopMenuOrigins;
+import in.koreatech.koin.domain.order.shop.model.entity.shop.ShopOperation;
 import in.koreatech.koin.domain.shop.model.event.EventArticle;
 import in.koreatech.koin.domain.shop.model.menu.Menu;
 import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
@@ -43,10 +46,6 @@ public class Shop extends BaseEntity {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Integer id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id", referencedColumnName = "user_id")
-    private Owner owner;
 
     @Size(max = 50)
     @NotNull

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
@@ -1,0 +1,60 @@
+package in.koreatech.koin.domain.shop.model.shop;
+
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "shop_categories")
+public class ShopCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @Size(max = 255)
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Size(max = 255)
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Size(max = 255)
+    @Column(name = "event_banner_image_url")
+    private String eventBannerImageUrl;
+
+    @NotNull
+    @PositiveOrZero
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex = 0;
+
+    @OneToMany(mappedBy = "shopCategory", orphanRemoval = true, cascade = {PERSIST, REMOVE})
+    private List<ShopCategoryMap> shopCategoryMaps = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_category_id", referencedColumnName = "id")
+    private ShopParentCategory parentCategory;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategoryMap.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategoryMap.java
@@ -1,0 +1,49 @@
+package in.koreatech.koin.domain.shop.model.shop;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shop_category_map",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "SHOP_ID_AND_SHOP_CATEGORY_ID",
+            columnNames = {"shop_id", "shop_category_id"}
+        )
+    }
+)
+public class ShopCategoryMap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", referencedColumnName = "id", nullable = false)
+    private Shop shop;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_category_id", referencedColumnName = "id", nullable = false)
+    private ShopCategory shopCategory;
+
+    @Builder
+    private ShopCategoryMap(Shop shop, ShopCategory shopCategory) {
+        this.shop = shop;
+        this.shopCategory = shopCategory;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopImage.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopImage.java
@@ -1,0 +1,44 @@
+package in.koreatech.koin.domain.shop.model.shop;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shop_images",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "SHOP_ID_AND_IMAGE_URL",
+            columnNames = {"shop_id", "image_url"}
+        )
+    }
+)
+public class ShopImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", referencedColumnName = "id", nullable = false)
+    private Shop shop;
+
+    @Size(max = 255)
+    @Column(name = "image_url")
+    private String imageUrl;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopNotificationMessage.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopNotificationMessage.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.domain.shop.model.shop;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shop_notification_messages")
+public class ShopNotificationMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Size(max = 255)
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Size(max = 255)
+    @Column(name = "content", nullable = false)
+    private String content;
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopOpen.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopOpen.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 import org.hibernate.annotations.Where;
 
-import in.koreatech.common.converter.LocalTimeAttributeConverter;
+import in.koreatech.koin.common.converter.LocalTimeAttributeConverter;
 import in.koreatech.payment.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopOpen.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopOpen.java
@@ -1,0 +1,98 @@
+package in.koreatech.koin.domain.shop.model.shop;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalTime;
+import java.util.Map;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.common.converter.LocalTimeAttributeConverter;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shop_opens")
+@Where(clause = "is_deleted=0")
+public class ShopOpen extends BaseEntity implements Comparable<ShopOpen> {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", referencedColumnName = "id", nullable = false)
+    private Shop shop;
+
+    @Size(max = 10)
+    @Column(name = "day_of_week", nullable = false)
+    private String dayOfWeek;
+
+    @NotNull
+    @Column(name = "closed", nullable = false)
+    private boolean closed;
+
+    @NotNull
+    @Column(name = "open_time")
+    @Convert(converter = LocalTimeAttributeConverter.class)
+    private LocalTime openTime;
+
+    @NotNull
+    @Column(name = "close_time")
+    @Convert(converter = LocalTimeAttributeConverter.class)
+    private LocalTime closeTime;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    private static final Map<String, Integer> dayOfWeekOrder = Map.of(
+        "MONDAY", 1,
+        "TUESDAY", 2,
+        "WEDNESDAY", 3,
+        "THURSDAY", 4,
+        "FRIDAY", 5,
+        "SATURDAY", 6,
+        "SUNDAY", 7
+    );
+
+    @Builder
+    private ShopOpen(
+        Shop shop,
+        String dayOfWeek,
+        boolean closed,
+        LocalTime openTime,
+        LocalTime closeTime
+    ) {
+        this.shop = shop;
+        this.dayOfWeek = dayOfWeek;
+        this.closed = closed;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+    }
+
+    @Override
+    public int compareTo(ShopOpen other) {
+        int dayComparison = dayOfWeekOrder.get(this.dayOfWeek).compareTo(dayOfWeekOrder.get(other.dayOfWeek));
+        if (dayComparison != 0) {
+            return dayComparison;
+        }
+        return this.openTime.compareTo(other.openTime);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopParentCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopParentCategory.java
@@ -1,0 +1,39 @@
+package in.koreatech.koin.domain.shop.model.shop;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "shop_parent_categories")
+public class ShopParentCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @Size(max = 255)
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_message_id", referencedColumnName = "id", nullable = false)
+    private ShopNotificationMessage notificationMessage;
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #28 

# 🚀 작업 내용

- 결제 WAS에서 koin DB에 write를 하기 위해, 상점 관련 엔티티 클래스를 추가 했습니다.

# 💬 리뷰 중점사항
코인 복붙