### PR TITLE
feat: 주문 관련 엔티티 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/model/Order.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/Order.java
@@ -1,0 +1,76 @@
+package in.koreatech.koin.domain.order.model;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static java.lang.Boolean.FALSE;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.payment.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(schema = "koin", name = "order")
+@Where(clause = "is_deleted=0")
+@NoArgsConstructor(access = PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @NotBlank
+    @Size(min = 6, max = 64)
+    @Column(name = "id", length = 64, nullable = false, updatable = false)
+    private String id;
+
+    @NotNull
+    @Enumerated(STRING)
+    @Column(name = "order_type", length = 10, nullable = false, updatable = false)
+    private OrderType orderType;
+
+    @NotBlank
+    @Size(max = 20)
+    @Column(name = "phone_number", length = 20, nullable = false, updatable = false)
+    private String phoneNumber;
+
+    @NotNull
+    @Column(name = "total_product_price", nullable = false, updatable = false)
+    private Integer totalProductPrice;
+
+    @NotNull
+    @Column(name = "total_price", nullable = false, updatable = false)
+    private Integer totalPrice;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = FALSE;
+
+    @JoinColumn(name = "orderable_shop_id")
+    @ManyToOne(fetch = LAZY)
+    private OrderableShop orderableShop;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @OneToOne(mappedBy = "order", fetch = LAZY, cascade = ALL)
+    private OrderDelivery orderDelivery;
+
+    @OneToOne(mappedBy = "order", fetch = LAZY, cascade = ALL)
+    private OrderTakeout orderTakeout;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderDelivery.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderDelivery.java
@@ -1,0 +1,51 @@
+package in.koreatech.koin.domain.order.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "order_delivery")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderDelivery {
+
+    @Id
+    @Column(name = "order_id", nullable = false, updatable = false)
+    private String id;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+    private Order order;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "address", length = 100, nullable = false, updatable = false)
+    private String address;
+
+    @NotNull
+    @Size(max = 50)
+    @Column(name = "to_owner", length = 50, nullable = false, updatable = false)
+    private String toOwner;
+
+    @NotNull
+    @Size(max = 50)
+    @Column(name = "to_rider", length = 50, nullable = false, updatable = false)
+    private String toRider;
+
+    @NotNull
+    @Column(name = "delivery_tip", nullable = false, updatable = false)
+    private Integer deliveryTip;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderMenu.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderMenu.java
@@ -1,0 +1,53 @@
+package in.koreatech.koin.domain.order.model;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(schema = "koin", name = "order_menu")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderMenu {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotBlank
+    @Column(name = "menu_name", nullable = false, updatable = false)
+    private String menuName;
+
+    @NotNull
+    @Column(name = "menu_price", nullable = false, updatable = false)
+    private Integer menuPrice;
+
+    @NotNull
+    @Column(name = "quantity", nullable = false, updatable = false)
+    private Integer quantity;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @OneToMany(mappedBy = "orderMenu", cascade = ALL, orphanRemoval = true)
+    private List<OrderMenuOption> orderMenuOptions = new ArrayList<>();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderMenuOption.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderMenuOption.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.domain.order.model;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(schema = "koin", name = "order_menu_option")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderMenuOption {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @NotBlank
+    @Column(name = "option_name", nullable = false, updatable = false)
+    private String optionName;
+
+    @NotNull
+    @Column(name = "option_price", nullable = false, updatable = false)
+    private Integer optionPrice;
+
+    @NotNull
+    @Column(name = "quantity", nullable = false, updatable = false)
+    private Integer quantity;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_menu_id", nullable = false)
+    private OrderMenu orderMenu;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderTakeout.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderTakeout.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.domain.order.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "order_takeout")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderTakeout {
+
+    @Id
+    @Column(name = "order_id", nullable = false, updatable = false)
+    private String id;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+    private Order order;
+
+    @NotNull
+    @Size(max = 50)
+    @Column(name = "to_owner", length = 50, nullable = false, updatable = false)
+    private String toOwner;
+}

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderType.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderType.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.domain.order.model;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderType {
+    DELIVERY("배달"),
+    TAKE_OUT("포장"),
+    ;
+
+    private final String name;
+
+    OrderType(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #32 

# 🚀 작업 내용

- 코인 DB에 반영된 주문 엔티티 클래스를 추가했습니다.

# 💬 리뷰 중점사항
결제 엔티티 수정의 경우, 결제 승인 API를 수정하면서 반영하겠습니다.