### PR TITLE
fix: 토스 페이먼츠 인증 헤더 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
+++ b/src/main/java/in/koreatech/payment/client/TossPaymentClient.java
@@ -95,7 +95,7 @@ public class TossPaymentClient {
     }
 
     private String buildAuthorizationHeader() {
-        String encoded = Base64.getEncoder().encodeToString((secretKey).getBytes(UTF_8));
+        String encoded = Base64.getEncoder().encodeToString((secretKey + ":").getBytes(UTF_8));
         return AUTH_PREFIX + encoded;
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #36 

# 🚀 작업 내용

- 토스 페이먼츠 인증 헤더 로직을 수정했습니다.
  - 기존에는 application.yml에 `:`를 같이 저장했는데, 이를 코드 상에서 붙이는 걸로 수정했습니다.

# 💬 리뷰 중점사항
