### PR TITLE
fix: 토스 페이먼츠 성공 응답값 파싱 필드 수정

### DIFF
--- a/src/main/java/in/koreatech/payment/client/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/in/koreatech/payment/client/dto/response/PaymentConfirmResponse.java
@@ -9,7 +9,7 @@ import in.koreatech.koin.domain.order.model.PaymentStatus;
 
 public record PaymentConfirmResponse(
     String paymentKey,
-    Integer amount,
+    Integer totalAmount,
     String status,
     String method,
     String requestedAt,
@@ -24,7 +24,7 @@ public record PaymentConfirmResponse(
 
         return Payment.builder()
             .paymentKey(paymentKey)
-            .amount(amount)
+            .amount(totalAmount)
             .paymentStatus(PaymentStatus.valueOf(status))
             .paymentMethod(PaymentMethod.from(method))
             .requestedAt(requested)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #44 

# 🚀 작업 내용

- 토스 페이먼츠에서 내려주는 성공 객체를 파싱하는 과정에서 생기는 문제를 해결했습니다.
  - amount이 아닌 totalAmount으로 수정했습니다.

# 💬 리뷰 중점사항
