### PR TITLE
fix: 결제취소 API 경로 변수 변경

### DIFF
--- a/src/main/java/in/koreatech/payment/controller/PaymentsApi.java
+++ b/src/main/java/in/koreatech/payment/controller/PaymentsApi.java
@@ -164,13 +164,13 @@ public interface PaymentsApi {
             취소 사유는 요청 본문에 포함됩니다.
             
             ## Path Variable
-            - `paymentKey`: PG사에서 받은 결제 키
+            - `paymentId`: 결제 고유 ID
             """
     )
-    @PostMapping("/{paymentKey}/cancel")
+    @PostMapping("/{paymentId}/cancel")
     ResponseEntity<PaymentCancelResponse> cancelPayment(
-        @Parameter(description = "결제 키", example = "5EnNZRJGvaBX7zk2yd8ydw26XvwXkLrx9POLqKQjmAw4b0e1")
-        @PathVariable(value = "paymentKey") final String paymentKey,
+        @Parameter(description = "결제 고유 ID", example = "1")
+        @PathVariable(value = "paymentId") final Integer paymentId,
         @RequestBody @Valid final PaymentCancelRequest request,
         @AccessToken final String accessToken
     );

--- a/src/main/java/in/koreatech/payment/controller/PaymentsController.java
+++ b/src/main/java/in/koreatech/payment/controller/PaymentsController.java
@@ -61,13 +61,13 @@ public class PaymentsController implements PaymentsApi {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/{paymentKey}/cancel")
+    @PostMapping("/{paymentId}/cancel")
     public ResponseEntity<PaymentCancelResponse> cancelPayment(
-        @PathVariable(value = "paymentKey") final String paymentKey,
+        @PathVariable(value = "paymentId") final Integer paymentId,
         @RequestBody @Valid final PaymentCancelRequest request,
         @AccessToken final String accessToken
     ) {
-        List<PaymentCancel> paymentCancels = paymentService.cancelPayment(accessToken, paymentKey,
+        List<PaymentCancel> paymentCancels = paymentService.cancelPayment(accessToken, paymentId,
             request.cancelReason());
         PaymentCancelResponse response = PaymentCancelResponse.from(paymentCancels);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/payment/service/PaymentService.java
+++ b/src/main/java/in/koreatech/payment/service/PaymentService.java
@@ -12,6 +12,6 @@ public interface PaymentService {
     String createTemporaryDeliveryPayment(String accessToken, TemporaryDeliveryPaymentSaveRequest request);
     String createTemporaryTakeoutPayment(String accessToken, TemporaryTakeoutPaymentSaveRequest request);
     PaymentConfirmResponse confirmPayment(String accessToken, String paymentKey, String orderId, Integer amount);
-    List<PaymentCancel> cancelPayment(String accessToken, String paymentKey, String cancelReason);
+    List<PaymentCancel> cancelPayment(String accessToken, Integer paymentId, String cancelReason);
     PaymentResponse getPayment(String accessToken, Integer paymentId);
 }

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -177,10 +177,10 @@ public class TossService implements PaymentService {
     }
 
     @Transactional
-    public List<PaymentCancel> cancelPayment(String accessToken, String paymentKey, String cancelReason) {
+    public List<PaymentCancel> cancelPayment(String accessToken, Integer paymentId, String cancelReason) {
         Integer userId = jwtTokenResolver.getUserId(accessToken);
         User user = userRepository.getById(userId);
-        Payment payment = paymentRepository.getByPaymentKey(paymentKey);
+        Payment payment = paymentRepository.getById(paymentId);
         if (payment.getPaymentStatus().isCanceled()) {
             throw PaymentAlreadyCanceledException.withDetail("paymentId : " + payment.getId());
         }
@@ -201,7 +201,7 @@ public class TossService implements PaymentService {
                     .build()
             ));
 
-        PaymentCancelResponse response = tossPaymentClient.requestCancel(paymentKey, cancelReason,
+        PaymentCancelResponse response = tossPaymentClient.requestCancel(payment.getPaymentKey(), cancelReason,
             paymentIdempotencyKey.getIdempotencyKey());
         if (!PaymentStatus.valueOf(response.status()).isCanceled()) {
             throw PaymentCancelException.withDetail("paymentStatus : " + response.status());


### PR DESCRIPTION
# 🔥 연관 이슈

- close #67 

# 🚀 작업 내용

- 결제 취소 API 경로 변수 값을 변경했습니다.
  - paymentKey -> paymentId


# 💬 리뷰 중점사항
