### PR TITLE
test: 토스 페이먼츠 클라이언트 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.squareup.okhttp3:mockwebserver'
 }
 
 clean {

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -82,6 +82,12 @@ public class TossPaymentClientTest {
             assertThat(request.getHeader("Content-Type")).startsWith("application/json");
             String expectedAuth = "Basic " + Base64.getEncoder().encodeToString("test_sk:".getBytes(UTF_8));
             assertThat(request.getHeader("Authorization")).isEqualTo(expectedAuth);
+
+
+            String body = request.getBody().readUtf8();
+            assertThat(body).contains("\"paymentKey\":\"pay_123\"");
+            assertThat(body).contains("\"orderId\":\"a4CWyWY5m89PNh7xJwhk1\"");
+            assertThat(body).contains("\"amount\":15000");
         }
     }
 

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -79,10 +79,14 @@ public class TossPaymentClientTest {
             RecordedRequest request = mockHttpServer.takeRequest();
             assertThat(request.getPath()).isEqualTo("/confirm");
             assertThat(request.getMethod()).isEqualTo("POST");
+
             assertThat(request.getHeader("Content-Type")).startsWith("application/json");
             String expectedAuth = "Basic " + Base64.getEncoder().encodeToString("test_sk:".getBytes(UTF_8));
-            assertThat(request.getHeader("Authorization")).isEqualTo(expectedAuth);
-
+            assertThat(request.getHeader("Authorization"))
+                .isEqualTo(expectedAuth)
+                .startsWith("Basic ")
+                .doesNotContain("\n")
+                .doesNotContain("\r");
 
             String body = request.getBody().readUtf8();
             assertThat(body).contains("\"paymentKey\":\"pay_123\"");

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -192,4 +192,38 @@ public class TossPaymentClientTest {
             assertThat(body).contains("\"cancelReason\":\"단순 변심이에요\"");
         }
     }
+
+    @Nested
+    class PaymentCancelFailure {
+
+        @Test
+        void 결제_취소_요청_실패시_INVALID_REQUEST_예외를_던진다() throws Exception {
+            // given
+            String errorJson = """
+                {
+                  "code": "INVALID_REQUEST",
+                  "message": "잘못된 요청입니다."
+                }
+                """;
+            mockHttpServer.enqueueJson(errorJson, 400);
+
+            // when
+            TossPaymentException exception = assertThrows(
+                TossPaymentException.class,
+                () -> tossPaymentClient.requestCancel(
+                    "pay_123",
+                    null,
+                    "91b0343a-423d-431d-832c-031d9391afae"
+                )
+            );
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo("INVALID_REQUEST");
+            assertThat(exception).hasMessage("잘못된 요청입니다.");
+
+            RecordedRequest request = mockHttpServer.takeRequest();
+            assertThat(request.getPath()).isEqualTo("/pay_123/cancel");
+            assertThat(request.getMethod()).isEqualTo("POST");
+        }
+    }
 }

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -46,7 +46,7 @@ public class TossPaymentClientTest {
     }
 
     @Nested
-    class PaymentSuccess {
+    class PaymentConfirmSuccess {
 
         @Test
         void 결제_승인_요청에_성공한다() throws Exception {
@@ -96,7 +96,7 @@ public class TossPaymentClientTest {
     }
 
     @Nested
-    class PaymentFailure {
+    class PaymentConfirmFailure {
 
         @ParameterizedTest
         @MethodSource("invalidParams")

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -1,11 +1,13 @@
 package in.koreatech.payment.unit.client;
 
+import static in.koreatech.payment.client.dto.response.PaymentCancelResponse.CancelInfo;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Base64;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -19,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import in.koreatech.payment.client.TossPaymentClient;
+import in.koreatech.payment.client.dto.response.PaymentCancelResponse;
 import in.koreatech.payment.client.dto.response.TossPaymentConfirmResponse;
 import in.koreatech.payment.client.exception.TossPaymentException;
 import in.koreatech.payment.unit.support.MockHttpServer;
@@ -131,6 +134,62 @@ public class TossPaymentClientTest {
                 Arguments.of("pay_123", null, 99999),
                 Arguments.of("pay_123", "a4CWyWY5m89PNh7xJwhk1", null)
             );
+        }
+    }
+
+    @Nested
+    class PaymentCancelSuccess {
+
+        @Test
+        void 결제_취소_요청을_성공한다() throws Exception {
+            // given
+            PaymentCancelResponse dto = new PaymentCancelResponse(
+                "pay_123",
+                "a4CWyWY5m89PNh7xJwhk1",
+                "CANCELED",
+                List.of(new CancelInfo(
+                    10000,
+                    "단순 변심이에요",
+                    "2024-01-01T10:00:00+09:00",
+                    "txrd_123"
+                ))
+            );
+            mockHttpServer.enqueueJson(objectMapper.writeValueAsString(dto), 200);
+
+            // when
+            PaymentCancelResponse response = tossPaymentClient.requestCancel(
+                "pay_123",
+                "단순 변심이에요",
+                "91b0343a-423d-431d-832c-031d9391afae"
+            );
+
+            // then
+            assertAll(
+                () -> assertThat(response.paymentKey()).isEqualTo("pay_123"),
+                () -> assertThat(response.orderId()).isEqualTo("a4CWyWY5m89PNh7xJwhk1"),
+                () -> assertThat(response.status()).isEqualTo("CANCELED"),
+                () -> assertThat(response.cancels()).hasSize(1),
+                () -> assertThat(response.cancels().get(0).cancelAmount()).isEqualTo(10000),
+                () -> assertThat(response.cancels().get(0).cancelReason()).isEqualTo("단순 변심이에요"),
+                () -> assertThat(response.cancels().get(0).canceledAt()).isEqualTo("2024-01-01T10:00:00+09:00"),
+                () -> assertThat(response.cancels().get(0).transactionKey()).isEqualTo("txrd_123")
+            );
+
+            RecordedRequest request = mockHttpServer.takeRequest();
+            assertThat(request.getPath()).isEqualTo("/pay_123/cancel");
+            assertThat(request.getMethod()).isEqualTo("POST");
+
+            assertThat(request.getHeader("Content-Type")).startsWith("application/json");
+            assertThat(request.getHeader("Idempotency-Key")).isEqualTo("91b0343a-423d-431d-832c-031d9391afae");
+            String expectedAuth = "Basic " + Base64.getEncoder().encodeToString("test_sk:".getBytes(UTF_8));
+            assertThat(request.getHeader("Authorization"))
+                .isEqualTo(expectedAuth)
+                .startsWith("Basic ")
+                .doesNotContain("\n")
+                .doesNotContain("\r");
+
+            String body = request.getBody().readUtf8();
+            assertThat(body).contains("\"cancelReason\":\"단순 변심이에요\"");
         }
     }
 }

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -1,20 +1,27 @@
 package in.koreatech.payment.unit.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import in.koreatech.payment.client.TossPaymentClient;
 import in.koreatech.payment.client.dto.response.TossPaymentConfirmResponse;
+import in.koreatech.payment.client.exception.TossPaymentException;
 import in.koreatech.payment.unit.support.MockHttpServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -77,6 +84,45 @@ public class TossPaymentClientTest {
             String expectedAuth = "Basic " + Base64.getEncoder()
                 .encodeToString("test_sk:".getBytes(StandardCharsets.UTF_8));
             assertThat(request.getHeader("Authorization")).isEqualTo(expectedAuth);
+        }
+    }
+
+    @Nested
+    class PaymentFailure {
+
+        @ParameterizedTest
+        @MethodSource("invalidParams")
+        void 결제_승인_과정에서_필수값이_누락되면_INVALID_REQUEST_예외를_던진다(
+            String paymentKey, String orderId, Integer amount
+        ) throws Exception {
+            // given
+            String errorJson = """
+                {
+                  "code": "INVALID_REQUEST",
+                  "message": "잘못된 요청입니다."
+                }
+                """;
+            mockHttpServer.enqueueJson(errorJson, 400);
+
+            // when & then
+            TossPaymentException exception = assertThrows(
+                TossPaymentException.class,
+                () -> tossPaymentClient.requestConfirm(paymentKey, orderId, amount)
+            );
+            assertThat(exception.getErrorCode()).isEqualTo("INVALID_REQUEST");
+            assertThat(exception).hasMessage("잘못된 요청입니다.");
+
+            RecordedRequest request = mockHttpServer.takeRequest();
+            assertThat(request.getPath()).isEqualTo("/confirm");
+            assertThat(request.getMethod()).isEqualTo("POST");
+        }
+
+        static Stream<Arguments> invalidParams() {
+            return Stream.of(
+                Arguments.of(null, "a4CWyWY5m89PNh7xJwhk1", 99999),
+                Arguments.of("pay_123", null, 99999),
+                Arguments.of("pay_123", "a4CWyWY5m89PNh7xJwhk1", null)
+            );
         }
     }
 }

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -1,11 +1,10 @@
 package in.koreatech.payment.unit.client;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.stream.Stream;
 
@@ -80,9 +79,8 @@ public class TossPaymentClientTest {
             RecordedRequest request = mockHttpServer.takeRequest();
             assertThat(request.getPath()).isEqualTo("/confirm");
             assertThat(request.getMethod()).isEqualTo("POST");
-
-            String expectedAuth = "Basic " + Base64.getEncoder()
-                .encodeToString("test_sk:".getBytes(StandardCharsets.UTF_8));
+            assertThat(request.getHeader("Content-Type")).startsWith("application/json");
+            String expectedAuth = "Basic " + Base64.getEncoder().encodeToString("test_sk:".getBytes(UTF_8));
             assertThat(request.getHeader("Authorization")).isEqualTo(expectedAuth);
         }
     }

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -1,0 +1,82 @@
+package in.koreatech.payment.unit.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import in.koreatech.payment.client.TossPaymentClient;
+import in.koreatech.payment.client.dto.response.TossPaymentConfirmResponse;
+import in.koreatech.payment.unit.support.MockHttpServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class TossPaymentClientTest {
+
+    private MockHttpServer mockHttpServer;
+    private TossPaymentClient tossPaymentClient;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        mockHttpServer = new MockHttpServer();
+        objectMapper = new ObjectMapper();
+        String baseUrl = mockHttpServer.baseUrl();
+        String secretKey = "test_sk";
+
+        tossPaymentClient = new TossPaymentClient(objectMapper, baseUrl, secretKey);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockHttpServer.shutdown();
+    }
+
+    @Nested
+    class PaymentSuccess {
+
+        @Test
+        void 결제를_승인한다() throws Exception {
+            // given
+            TossPaymentConfirmResponse dto = new TossPaymentConfirmResponse(
+                "pay_123",
+                15000,
+                "DONE",
+                "CARD",
+                "2024-01-01T10:00:00+09:00",
+                "2024-01-01T10:00:05+09:00"
+            );
+            mockHttpServer.enqueueJson(objectMapper.writeValueAsString(dto), 200);
+
+            // when
+            TossPaymentConfirmResponse response = tossPaymentClient.requestConfirm(
+                "pay_123",
+                "a4CWyWY5m89PNh7xJwhk1",
+                15000
+            );
+
+            // then
+            assertAll(
+                () -> assertThat(response.paymentKey()).isEqualTo("pay_123"),
+                () -> assertThat(response.totalAmount()).isEqualTo(15000),
+                () -> assertThat(response.status()).isEqualTo("DONE"),
+                () -> assertThat(response.method()).isEqualTo("CARD")
+            );
+
+            RecordedRequest request = mockHttpServer.takeRequest();
+            assertThat(request.getPath()).isEqualTo("/confirm");
+            assertThat(request.getMethod()).isEqualTo("POST");
+
+            String expectedAuth = "Basic " + Base64.getEncoder()
+                .encodeToString("test_sk:".getBytes(StandardCharsets.UTF_8));
+            assertThat(request.getHeader("Authorization")).isEqualTo(expectedAuth);
+        }
+    }
+}

--- a/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
+++ b/src/test/java/in/koreatech/payment/unit/client/TossPaymentClientTest.java
@@ -50,7 +50,7 @@ public class TossPaymentClientTest {
     class PaymentSuccess {
 
         @Test
-        void 결제를_승인한다() throws Exception {
+        void 결제_승인_요청에_성공한다() throws Exception {
             // given
             TossPaymentConfirmResponse dto = new TossPaymentConfirmResponse(
                 "pay_123",
@@ -92,7 +92,7 @@ public class TossPaymentClientTest {
 
         @ParameterizedTest
         @MethodSource("invalidParams")
-        void 결제_승인_과정에서_필수값이_누락되면_INVALID_REQUEST_예외를_던진다(
+        void 결제_승인_요청_과정에서_필수값이_누락되면_INVALID_REQUEST_예외를_던진다(
             String paymentKey, String orderId, Integer amount
         ) throws Exception {
             // given

--- a/src/test/java/in/koreatech/payment/unit/support/MockHttpServer.java
+++ b/src/test/java/in/koreatech/payment/unit/support/MockHttpServer.java
@@ -1,0 +1,44 @@
+package in.koreatech.payment.unit.support;
+
+import java.io.IOException;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class MockHttpServer {
+
+    private final MockWebServer mockWebServer;
+
+    public MockHttpServer() {
+        try {
+            this.mockWebServer = new MockWebServer();
+            this.mockWebServer.start();
+        } catch (IOException e) {
+            throw new IllegalStateException("mock web server failed", e);
+        }
+    }
+
+    public String baseUrl() {
+        return mockWebServer.url("/").toString();
+    }
+
+    public void enqueueJson(String json, int statusCode) {
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(statusCode)
+            .setHeader("Content-Type", "application/json")
+            .setBody(json));
+    }
+
+    public RecordedRequest takeRequest() throws InterruptedException {
+        return mockWebServer.takeRequest();
+    }
+
+    public void shutdown() {
+        try {
+            mockWebServer.shutdown();
+        } catch (IOException e) {
+            throw new IllegalStateException("mock web server failed", e);
+        }
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #71 

# 🚀 작업 내용

- [토스 페이먼츠 클라이언트 클래스](https://github.com/BCSDLab/KOIN_PAYMENT_API/tree/develop/src/main/java/in/koreatech/payment/client)의 테스트 코드를 추가했습니다.
  - 결제 승인 요청, 결제 취소 요청 2가지에 대해서 추가했습니다.
  - 성공 케이스와 실패 케이스(요청값 유효성 검증)에 대해서 작성했습니다.
- 실제 토스 페이먼츠 API 호출 대신 [MockWebServer](https://www.notion.so/MockWebServer-2519ae650b5980218898f2124a50aa79?source=copy_link)를 활용해 응답을 모킹했습니다.
  - 결제키(paymentKey)의 경우 클라이언트를 통해 얻을 수 있는 것으로 알고 있습니다.

# 💬 리뷰 중점사항
성공 케이스 테스트에서는 다음 사항을 검증했습니다.
- 요청 경로: 요청이 엔드포인트로 정상적으로 들어왔는지
- 요청 헤더: Authorization, Idempotency-Key(멱등키) 등 필수 헤더가 정상적으로 포함되는지
- 요청 바디: 결제 승인/취소 요청 값이 의도한 대로 전달되는지
- 응답 값: Mock 응답이 정상적으로 매핑되어 의도한 DTO 형태로 반환되는지

에러 클래스가 코인 서버랑 상이한데, 리펙토링 과정에서 수정 예정입니다.