### PR TITLE
refactor: order 테이블 pk 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/model/Order.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/Order.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.order.model;
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
 import static java.lang.Boolean.FALSE;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -14,6 +15,7 @@ import in.koreatech.payment.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -34,10 +36,13 @@ import lombok.NoArgsConstructor;
 public class Order extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
     @NotBlank
     @Size(min = 6, max = 64)
-    @Column(name = "id", length = 64, nullable = false, updatable = false)
-    private String id;
+    @Column(name = "pg_order_id", length = 64, nullable = false, updatable = false)
+    private String pgOrderId;
 
     @NotNull
     @Enumerated(STRING)
@@ -76,17 +81,21 @@ public class Order extends BaseEntity {
     private OrderTakeout orderTakeout;
 
     @Builder
-    public Order(
-        String id,
+    private Order(
+        Integer id,
+        String pgOrderId,
         OrderType orderType,
         String phoneNumber,
         Integer totalProductPrice,
         Integer totalPrice,
         Boolean isDeleted,
         OrderableShop orderableShop,
-        User user
+        User user,
+        OrderDelivery orderDelivery,
+        OrderTakeout orderTakeout
     ) {
         this.id = id;
+        this.pgOrderId = pgOrderId;
         this.orderType = orderType;
         this.phoneNumber = phoneNumber;
         this.totalProductPrice = totalProductPrice;
@@ -94,6 +103,8 @@ public class Order extends BaseEntity {
         this.isDeleted = isDeleted;
         this.orderableShop = orderableShop;
         this.user = user;
+        this.orderDelivery = orderDelivery;
+        this.orderTakeout = orderTakeout;
     }
 
     public void setOrderDelivery(OrderDelivery orderDelivery) {

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderDelivery.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderDelivery.java
@@ -24,7 +24,7 @@ public class OrderDelivery {
 
     @Id
     @Column(name = "order_id", nullable = false, updatable = false)
-    private String id;
+    private Integer id;
 
     @MapsId
     @OneToOne

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderTakeout.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderTakeout.java
@@ -23,7 +23,7 @@ public class OrderTakeout {
 
     @Id
     @Column(name = "order_id", nullable = false, updatable = false)
-    private String id;
+    private Integer id;
 
     @MapsId
     @OneToOne

--- a/src/main/java/in/koreatech/koin/domain/order/repository/OrderMenuRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/repository/OrderMenuRepository.java
@@ -10,5 +10,5 @@ public interface OrderMenuRepository extends Repository<OrderMenu, Integer> {
 
     void saveAll(Iterable<OrderMenu> orderMenus);
 
-    List<OrderMenu> findAllByOrderId(String orderId);
+    List<OrderMenu> findAllByOrderId(Integer orderId);
 }

--- a/src/main/java/in/koreatech/payment/model/redis/TemporaryPayment.java
+++ b/src/main/java/in/koreatech/payment/model/redis/TemporaryPayment.java
@@ -27,7 +27,7 @@ public class TemporaryPayment {
     private static final Long CACHE_EXPIRE_SECOND = 60 * 10L;
 
     @Id
-    private String orderId;
+    private String pgOrderId;
 
     private Integer userId;
 
@@ -59,7 +59,7 @@ public class TemporaryPayment {
     private LocalDateTime createdAt;
 
     private TemporaryPayment(
-        String orderId,
+        String pgOrderId,
         Integer userId,
         Integer orderableShopId,
         String phoneNumber,
@@ -73,7 +73,7 @@ public class TemporaryPayment {
         Integer totalPrice,
         List<TemporaryMenuItems> temporaryMenuItems
     ) {
-        this.orderId = orderId;
+        this.pgOrderId = pgOrderId;
         this.userId = userId;
         this.orderableShopId = orderableShopId;
         this.phoneNumber = phoneNumber;
@@ -91,7 +91,7 @@ public class TemporaryPayment {
     }
 
     public static TemporaryPayment toDeliveryEntity(
-        String orderId,
+        String pgOrderId,
         Integer userId,
         Integer orderableShopId,
         String phoneNumber,
@@ -105,7 +105,7 @@ public class TemporaryPayment {
         List<TemporaryMenuItems> temporaryMenuItems
     ) {
         return new TemporaryPayment(
-            orderId,
+            pgOrderId,
             userId,
             orderableShopId,
             phoneNumber,
@@ -122,7 +122,7 @@ public class TemporaryPayment {
     }
 
     public static TemporaryPayment toTakeOutEntity(
-        String orderId,
+        String pgOrderId,
         Integer userId,
         Integer orderableShopId,
         String phoneNumber,
@@ -133,7 +133,7 @@ public class TemporaryPayment {
         List<TemporaryMenuItems> temporaryMenuItems
     ) {
         return new TemporaryPayment(
-            orderId,
+            pgOrderId,
             userId,
             orderableShopId,
             phoneNumber,
@@ -151,7 +151,7 @@ public class TemporaryPayment {
 
     public Order toOrder(User user, OrderableShop orderableShop) {
         Order order = Order.builder()
-            .id(orderId)
+            .pgOrderId(pgOrderId)
             .orderType(orderType)
             .phoneNumber(phoneNumber)
             .totalProductPrice(totalProductPrice)
@@ -181,15 +181,15 @@ public class TemporaryPayment {
         return order;
     }
 
-    public void validateMatches(String orderId, Integer userId, Integer amount) {
-        validateOrderIdMatches(orderId);
+    public void validateMatches(String pgOrderId, Integer userId, Integer amount) {
+        validatePgOrderIdMatches(pgOrderId);
         validateUserIdMatches(userId);
         validateAmountMatches(amount);
     }
 
-    private void validateOrderIdMatches(String orderId) {
-        if (!orderId.equals(this.orderId)) {
-            throw InvalidTemporaryPaymentException.withDetail("orderId : " + orderId);
+    private void validatePgOrderIdMatches(String pgOrderId) {
+        if (!pgOrderId.equals(this.pgOrderId)) {
+            throw InvalidTemporaryPaymentException.withDetail("orderId : " + pgOrderId);
         }
     }
 

--- a/src/main/java/in/koreatech/payment/repository/redis/TemporaryPaymentRedisRepository.java
+++ b/src/main/java/in/koreatech/payment/repository/redis/TemporaryPaymentRedisRepository.java
@@ -11,12 +11,12 @@ public interface TemporaryPaymentRedisRepository extends Repository<TemporaryPay
 
     void save(TemporaryPayment temporaryPayment);
 
-    Optional<TemporaryPayment> findById(String orderId);
+    Optional<TemporaryPayment> findById(String pgOrderId);
 
-    default TemporaryPayment getById(String orderId) {
-        return findById(orderId)
-            .orElseThrow(() -> TemporaryPaymentNotFoundException.withDetail("orderId : " + orderId));
+    default TemporaryPayment getById(String pgOrderId) {
+        return findById(pgOrderId)
+            .orElseThrow(() -> TemporaryPaymentNotFoundException.withDetail("pgOrderId : " + pgOrderId));
     }
 
-    void deleteById(String orderId);
+    void deleteById(String pgOrderId);
 }

--- a/src/main/java/in/koreatech/payment/service/TossPaymentRollBackService.java
+++ b/src/main/java/in/koreatech/payment/service/TossPaymentRollBackService.java
@@ -83,11 +83,11 @@ public class TossPaymentRollBackService implements PaymentRollBackService {
             List<PaymentCancel> paymentCancels = response.getPaymentCancels(payment);
             paymentCancelRepository.saveAll(paymentCancels);
 
-            temporaryPaymentRedisRepository.deleteById(order.getId());
+            temporaryPaymentRedisRepository.deleteById(order.getPgOrderId());
             cartRepository.deleteByUserId(user.getId());
         } catch (Exception e) {
             log.error("결제 취소 과정에서 오류 발생 - paymentId: {}, userId: {}, orderId: {}", event.paymentKey(),
-                temporaryPayment.getUserId(), temporaryPayment.getOrderId());
+                temporaryPayment.getUserId(), temporaryPayment.getPgOrderId());
         }
     }
 }

--- a/src/main/java/in/koreatech/payment/service/TossService.java
+++ b/src/main/java/in/koreatech/payment/service/TossService.java
@@ -40,7 +40,7 @@ import in.koreatech.payment.exception.PaymentConfirmException;
 import in.koreatech.payment.model.domain.TemporaryMenuItems;
 import in.koreatech.payment.model.redis.TemporaryPayment;
 import in.koreatech.payment.repository.redis.TemporaryPaymentRedisRepository;
-import in.koreatech.payment.util.OrderIdGenerator;
+import in.koreatech.payment.util.PgOrderIdGenerator;
 import in.koreatech.payment.util.TemporaryMenuItemConverter;
 import lombok.RequiredArgsConstructor;
 
@@ -49,7 +49,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class TossService implements PaymentService {
 
-    private final OrderIdGenerator orderIdGenerator;
+    private final PgOrderIdGenerator pgOrderIdGenerator;
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final TossPaymentClient tossPaymentClient;
@@ -85,10 +85,10 @@ public class TossService implements PaymentService {
                     + totalProductPrice + "finalAmount : " + finalAmount);
         }
 
-        String orderId = orderIdGenerator.generateOrderId();
+        String pgOrderId = pgOrderIdGenerator.generatePgOrderId();
 
         TemporaryPayment deliveryEntity = TemporaryPayment.toDeliveryEntity(
-            orderId,
+            pgOrderId,
             user.getId(),
             orderableShop.getId(),
             request.phoneNumber(),
@@ -103,7 +103,7 @@ public class TossService implements PaymentService {
         );
 
         temporaryPaymentRedisRepository.save(deliveryEntity);
-        return orderId;
+        return pgOrderId;
     }
 
     @Transactional
@@ -125,10 +125,10 @@ public class TossService implements PaymentService {
                 "totalProductPrice : " + totalProductPrice + "finalAmount : " + finalAmount);
         }
 
-        String orderId = orderIdGenerator.generateOrderId();
+        String pgOrderId = pgOrderIdGenerator.generatePgOrderId();
 
         TemporaryPayment deliveryEntity = TemporaryPayment.toTakeOutEntity(
-            orderId,
+            pgOrderId,
             user.getId(),
             orderableShop.getId(),
             request.phoneNumber(),
@@ -140,7 +140,7 @@ public class TossService implements PaymentService {
         );
 
         temporaryPaymentRedisRepository.save(deliveryEntity);
-        return orderId;
+        return pgOrderId;
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/payment/util/OrderIdGenerator.java
+++ b/src/main/java/in/koreatech/payment/util/OrderIdGenerator.java
@@ -1,5 +1,0 @@
-package in.koreatech.payment.util;
-
-public interface OrderIdGenerator {
-    String generateOrderId();
-}

--- a/src/main/java/in/koreatech/payment/util/PgOrderIdGenerator.java
+++ b/src/main/java/in/koreatech/payment/util/PgOrderIdGenerator.java
@@ -1,0 +1,5 @@
+package in.koreatech.payment.util;
+
+public interface PgOrderIdGenerator {
+    String generatePgOrderId();
+}

--- a/src/main/java/in/koreatech/payment/util/TossPaymentOrderIdGenerator.java
+++ b/src/main/java/in/koreatech/payment/util/TossPaymentOrderIdGenerator.java
@@ -5,7 +5,7 @@ import java.security.SecureRandom;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TossPaymentPgOrderIdGenerator implements PgOrderIdGenerator {
+public class TossPaymentOrderIdGenerator implements PgOrderIdGenerator {
 
     private static final String ORDER_ID_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
     private static final int ORDER_ID_MIN_LENGTH = 6;

--- a/src/main/java/in/koreatech/payment/util/TossPaymentPgOrderIdGenerator.java
+++ b/src/main/java/in/koreatech/payment/util/TossPaymentPgOrderIdGenerator.java
@@ -5,14 +5,14 @@ import java.security.SecureRandom;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TossPaymentOrderIdGenerator implements OrderIdGenerator {
+public class TossPaymentPgOrderIdGenerator implements PgOrderIdGenerator {
 
     private static final String ORDER_ID_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
     private static final int ORDER_ID_MIN_LENGTH = 6;
     private static final int ORDER_ID_MAX_LENGTH = 64;
     private final SecureRandom random = new SecureRandom();
 
-    public String generateOrderId() {
+    public String generatePgOrderId() {
         int length = ORDER_ID_MIN_LENGTH + random.nextInt(ORDER_ID_MAX_LENGTH - ORDER_ID_MIN_LENGTH + 1);
         StringBuilder sb = new StringBuilder(length);
         for (int index = 0; index < length; index++) {

--- a/src/test/java/in/koreatech/payment/acceptance/domain/PaymentApiTest.java
+++ b/src/test/java/in/koreatech/payment/acceptance/domain/PaymentApiTest.java
@@ -54,7 +54,7 @@ import in.koreatech.payment.common.auth.JwtProvider;
 import in.koreatech.payment.model.redis.TemporaryPayment;
 import in.koreatech.payment.repository.redis.TemporaryPaymentRedisRepository;
 import in.koreatech.payment.service.PaymentRollBackService;
-import in.koreatech.payment.util.OrderIdGenerator;
+import in.koreatech.payment.util.PgOrderIdGenerator;
 
 public class PaymentApiTest extends AcceptanceTest {
 
@@ -101,7 +101,7 @@ public class PaymentApiTest extends AcceptanceTest {
     private PaymentRollBackService paymentRollBackService;
 
     @MockBean
-    private OrderIdGenerator orderIdGenerator;
+    private PgOrderIdGenerator pgOrderIdGenerator;
 
     private User user;
     private String token;
@@ -132,7 +132,7 @@ public class PaymentApiTest extends AcceptanceTest {
 
         @Test
         void 임시_배달_결제_정보_저장에_성공한다() throws Exception {
-            given(orderIdGenerator.generateOrderId()).willReturn("FAKE_ORDER_123");
+            given(pgOrderIdGenerator.generatePgOrderId()).willReturn("FAKE_ORDER_123");
 
             mockMvc.perform(
                     post("/payments/delivery/temporary")
@@ -162,7 +162,7 @@ public class PaymentApiTest extends AcceptanceTest {
             TemporaryPayment temporaryPayment = temporaryPaymentRedisRepository.getById("FAKE_ORDER_123");
             assertSoftly(
                 softly -> {
-                    softly.assertThat(temporaryPayment.getOrderId()).isEqualTo("FAKE_ORDER_123");
+                    softly.assertThat(temporaryPayment.getPgOrderId()).isEqualTo("FAKE_ORDER_123");
                     softly.assertThat(temporaryPayment.getUserId()).isEqualTo(user.getId());
                     softly.assertThat(temporaryPayment.getOrderableShopId()).isEqualTo(orderableShop.getId());
                     softly.assertThat(temporaryPayment.getPhoneNumber()).isEqualTo("01012345678");
@@ -183,7 +183,7 @@ public class PaymentApiTest extends AcceptanceTest {
 
         @Test
         void 임시_포장_결제_정보_저장에_성공한다() throws Exception {
-            given(orderIdGenerator.generateOrderId()).willReturn("FAKE_ORDER_123");
+            given(pgOrderIdGenerator.generatePgOrderId()).willReturn("FAKE_ORDER_123");
 
             mockMvc.perform(
                     post("/payments/takeout/temporary")
@@ -209,7 +209,7 @@ public class PaymentApiTest extends AcceptanceTest {
             TemporaryPayment temporaryPayment = temporaryPaymentRedisRepository.getById("FAKE_ORDER_123");
             assertSoftly(
                 softly -> {
-                    softly.assertThat(temporaryPayment.getOrderId()).isEqualTo("FAKE_ORDER_123");
+                    softly.assertThat(temporaryPayment.getPgOrderId()).isEqualTo("FAKE_ORDER_123");
                     softly.assertThat(temporaryPayment.getUserId()).isEqualTo(user.getId());
                     softly.assertThat(temporaryPayment.getOrderableShopId()).isEqualTo(orderableShop.getId());
                     softly.assertThat(temporaryPayment.getPhoneNumber()).isEqualTo("01012345678");
@@ -245,7 +245,7 @@ public class PaymentApiTest extends AcceptanceTest {
             );
             when(tossPaymentClient.requestConfirm(eq("pay_123"), eq("FAKE_ORDER_123"), eq(24000)))
                 .thenReturn(confirmDto);
-            given(orderIdGenerator.generateOrderId()).willReturn("FAKE_ORDER_123");
+            given(pgOrderIdGenerator.generatePgOrderId()).willReturn("FAKE_ORDER_123");
 
             mockMvc.perform(
                     post("/payments/delivery/temporary")
@@ -324,11 +324,12 @@ public class PaymentApiTest extends AcceptanceTest {
                     softly.assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.DONE);
                     softly.assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.CARD);
 
-                    softly.assertThat(order.getId()).isEqualTo("FAKE_ORDER_123");
+                    softly.assertThat(order.getId()).isEqualTo(1);
                     softly.assertThat(order.getOrderType()).isEqualTo(OrderType.DELIVERY);
                     softly.assertThat(order.getPhoneNumber()).isEqualTo("01012345678");
                     softly.assertThat(order.getTotalProductPrice()).isEqualTo(24000);
                     softly.assertThat(order.getTotalPrice()).isEqualTo(24000);
+                    softly.assertThat(order.getPgOrderId()).isEqualTo("FAKE_ORDER_123");
 
                     softly.assertThat(orderTakeout).isNull();
 
@@ -360,7 +361,7 @@ public class PaymentApiTest extends AcceptanceTest {
             );
             when(tossPaymentClient.requestConfirm(eq("pay_123"), eq("FAKE_ORDER_123"), eq(24000)))
                 .thenReturn(confirmDto);
-            given(orderIdGenerator.generateOrderId()).willReturn("FAKE_ORDER_123");
+            given(pgOrderIdGenerator.generatePgOrderId()).willReturn("FAKE_ORDER_123");
 
             mockMvc.perform(
                     post("/payments/takeout/temporary")
@@ -434,11 +435,12 @@ public class PaymentApiTest extends AcceptanceTest {
                     softly.assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.DONE);
                     softly.assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.CARD);
 
-                    softly.assertThat(order.getId()).isEqualTo("FAKE_ORDER_123");
+                    softly.assertThat(order.getId()).isEqualTo(1);
                     softly.assertThat(order.getOrderType()).isEqualTo(OrderType.TAKE_OUT);
                     softly.assertThat(order.getPhoneNumber()).isEqualTo("01012345678");
                     softly.assertThat(order.getTotalProductPrice()).isEqualTo(24000);
                     softly.assertThat(order.getTotalPrice()).isEqualTo(24000);
+                    softly.assertThat(order.getPgOrderId()).isEqualTo("FAKE_ORDER_123");
 
                     softly.assertThat(orderTakeout.getToOwner()).isEqualTo("리뷰 이벤트 감사합니다.");
                     softly.assertThat(orderTakeout.getProvideCutlery()).isEqualTo(true);
@@ -468,7 +470,7 @@ public class PaymentApiTest extends AcceptanceTest {
             );
             when(tossPaymentClient.requestConfirm(eq("pay_123"), eq("FAKE_ORDER_123"), eq(24000)))
                 .thenReturn(confirmDto);
-            given(orderIdGenerator.generateOrderId()).willReturn("FAKE_ORDER_123");
+            given(pgOrderIdGenerator.generatePgOrderId()).willReturn("FAKE_ORDER_123");
 
             PaymentCancelResponse cancelDto = new PaymentCancelResponse(
                 "pay_123",

--- a/src/test/java/in/koreatech/payment/acceptance/support/DBInitializer.java
+++ b/src/test/java/in/koreatech/payment/acceptance/support/DBInitializer.java
@@ -46,7 +46,7 @@ public class DBInitializer {
         String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND AUTO_INCREMENT >= 1";
         List<String> dirtyTables = entityManager.createNativeQuery(sql).getResultList();
         for (String dirtyTable: dirtyTables) {
-            entityManager.createNativeQuery(String.format("ALTER TABLE %s AUTO_INCREMENT = 1", dirtyTable)).executeUpdate();
+            entityManager.createNativeQuery(String.format("ALTER TABLE `%s` AUTO_INCREMENT = 1", dirtyTable)).executeUpdate();
         }
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #79 

# 🚀 작업 내용

- order 테이블의 pk를 변경했습니다.
  - 현재 Order 테이블의 PK는 토스 페이먼츠에서 사용하는 주문번호 (orderId)
  - 토스 페이먼츠에 PK가 종속된 상태 (최소 6, 최대 64)
  - 또한 문자열 PK이기 때문에 FK/조인 성능에 문제가 생길 가능성 존재
<img width="1776" height="946" alt="Untitled" src="https://github.com/user-attachments/assets/7acc03b1-39a9-49d1-a25a-3501bead03b5" />

# 💬 리뷰 중점사항
